### PR TITLE
added taskcluster repos

### DIFF
--- a/client.py
+++ b/client.py
@@ -203,15 +203,17 @@ def filter_hg_commit_data(repository_url, push_type):
     return changelog
 
 
-def create_files_for_hg():
+def create_files_for_hg(repositories_holder):
     """
-    Main HG function. Takes every Mercurial repo from repositories.json and writes all the commit data of each repo in a
-    separate json file and generates a MD file for each repo as well.
+    Main HG function. Takes every Mercurial repo from a .json file which is populated with repositories and writes all
+     the commit data of each repo in a.
+    creates a json and MD file for each repo as well.
+    :param: repositories_holder: expects a .json file that contains a list of repositories
     :return: the end result is a .json and a .md file for every git repository. can be found inside hg_files/
     """
-    for repo in repositories["Mercurial"]:
-        repository_url = repositories["Mercurial"][repo]["url"]
-        repository_push_type = repositories["Mercurial"][repo]["configuration"]["push_type"]
+    for repo in repositories_holder["Mercurial"]:
+        repository_url = repositories_holder["Mercurial"][repo]["url"]
+        repository_push_type = repositories_holder["Mercurial"][repo]["configuration"]["push_type"]
         repository_name = repo
         hg_changes = filter_hg_commit_data(repository_url, repository_push_type)
         hg_json_name = "./hg_files/" + "{}.json".format(repository_name)
@@ -221,15 +223,17 @@ def create_files_for_hg():
         create_hg_md_table(repository_name)
 
 
-def create_files_for_git():
+def create_files_for_git(repositories_holder):
     """
-    Main GIT function. Takes every Git repo from repositories.json and writes all the commit data of each repo in a
-    separate json file and generates a MD file for each repo as well.
+    Main GIT function. Takes every Git repo from a .json file which is populated with repositories and writes all
+    the commit data of each repo in a.
+    creates a json and MD file for each repo as well.
+    :param: repositories_holder: expects a .json file that contains a list of repositories
     :return: the end result is a .json and a .md file for every git repository. can be found inside git_files/
     """
-    for repo in repositories["Github"]:
+    for repo in repositories_holder["Github"]:
         repository_name = repo
-        repository_team = repositories["Github"][repo]["team"]
+        repository_team = repositories_holder["Github"][repo]["team"]
         filter_git_commit_data(repository_name, repository_team)
         create_git_md_table(repository_name)
 
@@ -347,7 +351,7 @@ if __name__ == "__main__":
     git = Github(TOKEN)
     repositories_data = open("./repositories.json").read()
     repositories = json.loads(repositories_data)
-    create_files_for_git()
-    create_files_for_hg()
+    create_files_for_git(repositories)
+    create_files_for_hg(repositories)
     clear_file("main_md_table.md")
     generate_main_md_table()

--- a/git_files/taskcluster-auth.json
+++ b/git_files/taskcluster-auth.json
@@ -1,0 +1,95 @@
+{
+  "0": {
+    "lastChecked": "2018-11-25 14:05:23.262451"
+  },
+  "1": {
+    "sha": "ee8964bac335b073f41210c3968e7f12a5ec5341",
+    "url": "https://github.com/taskcluster/taskcluster-auth/commit/ee8964bac335b073f41210c3968e7f12a5ec5341",
+    "commiter_name": "djmitche",
+    "commiter_email": "dustin@v.igoro.us",
+    "commit_message": "Bug 1508846 - upgrade tc-lib-api",
+    "commit_date": "2018-11-21 20:12:20",
+    "files_changed": [
+      "package.json",
+      "src/v1.js",
+      "test/helper.js",
+      "yarn.lock"
+    ]
+  },
+  "2": {
+    "sha": "d0bc2154649c75406ff56757d126127289ee4e01",
+    "url": "https://github.com/taskcluster/taskcluster-auth/commit/d0bc2154649c75406ff56757d126127289ee4e01",
+    "commiter_name": "djmitche",
+    "commiter_email": null,
+    "commit_message": "Merge pull request #181 from djmitche/bug1505405  Bug 1505405 - upgrade tc-lib-pulse",
+    "commit_date": "2018-11-21 20:32:22",
+    "files_changed": [
+      "package.json",
+      "src/exchanges.js",
+      "yarn.lock"
+    ]
+  },
+  "3": {
+    "sha": "33052858d025cf67f128dff7fd55231c323c95b1",
+    "url": "https://github.com/taskcluster/taskcluster-auth/commit/33052858d025cf67f128dff7fd55231c323c95b1",
+    "commiter_name": "djmitche",
+    "commiter_email": "dustin@v.igoro.us",
+    "commit_message": "Bug 1505405 - upgrade tc-lib-pulse  This only affects the output references format (for RFC 128)",
+    "commit_date": "2018-11-20 19:13:43",
+    "files_changed": [
+      "package.json",
+      "src/exchanges.js",
+      "yarn.lock"
+    ]
+  },
+  "4": {
+    "sha": "9ed089f62916fa2a54967379cfb5bc35156b8cea",
+    "url": "https://github.com/taskcluster/taskcluster-auth/commit/9ed089f62916fa2a54967379cfb5bc35156b8cea",
+    "commiter_name": "djmitche",
+    "commiter_email": null,
+    "commit_message": "Merge pull request #180 from djmitche/bug1508395  Bug 1508395 - upgrade tc-lib-validate",
+    "commit_date": "2018-11-21 19:48:44",
+    "files_changed": [
+      "package.json",
+      "yarn.lock"
+    ]
+  },
+  "5": {
+    "sha": "052d624ea730559489f6984b8fb47b819e2ffe94",
+    "url": "https://github.com/taskcluster/taskcluster-auth/commit/052d624ea730559489f6984b8fb47b819e2ffe94",
+    "commiter_name": "djmitche",
+    "commiter_email": null,
+    "commit_message": "Merge pull request #182 from djmitche/bug1508849  Bug 1508849 - implement   -scope protection differently",
+    "commit_date": "2018-11-21 19:48:33",
+    "files_changed": [
+      "schemas/constants.yml",
+      "src/v1.js",
+      "test/client_test.js"
+    ]
+  },
+  "6": {
+    "sha": "b19103d6d2ac47d16e2086a283e04320651ff383",
+    "url": "https://github.com/taskcluster/taskcluster-auth/commit/b19103d6d2ac47d16e2086a283e04320651ff383",
+    "commiter_name": "djmitche",
+    "commiter_email": "dustin@v.igoro.us",
+    "commit_message": "Bug 1508849 - implement   -scope protection differently  The old solution used a negative lookbehind, which per https://json-schema.org/understanding-json-schema/reference/regular_expressions.html#regular-expressions is not supported in json-schema.  In fact, it's not supported in even fairly recent versions of Node.  This causes problems when validating schemas using those old versions of node (or using json-schema validators that do not support this form).  So, the new solution is to explicitly forbid those forms where used in creating clients and roles.  The result is much the same, as evidenced by the minimal changes to the tests.",
+    "commit_date": "2018-11-21 00:46:14",
+    "files_changed": [
+      "schemas/constants.yml",
+      "src/v1.js",
+      "test/client_test.js"
+    ]
+  },
+  "7": {
+    "sha": "e52d89a68dc312b5ca045558ff7d4011663312db",
+    "url": "https://github.com/taskcluster/taskcluster-auth/commit/e52d89a68dc312b5ca045558ff7d4011663312db",
+    "commiter_name": "djmitche",
+    "commiter_email": "dustin@v.igoro.us",
+    "commit_message": "Bug 1508395 - upgrade tc-lib-validate  The change ony affects the output of writeDocs.",
+    "commit_date": "2018-11-20 19:10:53",
+    "files_changed": [
+      "package.json",
+      "yarn.lock"
+    ]
+  }
+}

--- a/git_files/taskcluster-auth.md
+++ b/git_files/taskcluster-auth.md
@@ -1,0 +1,13 @@
+## TASKCLUSTER-AUTH COMMIT MARKDOWN TABLE SINCE 2018-11-18 16:03:59.730188
+
+| Commit Number | Commiter | Commit Message | Commit Url | Date | 
+|:---:|:----:|:----------------------------------:|:------:|:----:| 
+|7|djmitche|Bug 1508846 - upgrade tc-lib-api|[URL](https://github.com/taskcluster/taskcluster-auth/commit/ee8964bac335b073f41210c3968e7f12a5ec5341)|2018-11-21 20:12:20
+|6|djmitche|Merge pull request #181 from djmitche/bug1505405  Bug 1505405 - upgrade tc-lib-pulse|[URL](https://github.com/taskcluster/taskcluster-auth/commit/d0bc2154649c75406ff56757d126127289ee4e01)|2018-11-21 20:32:22
+|5|djmitche|Bug 1505405 - upgrade tc-lib-pulse  This only affects the output references format (for RFC 128)|[URL](https://github.com/taskcluster/taskcluster-auth/commit/33052858d025cf67f128dff7fd55231c323c95b1)|2018-11-20 19:13:43
+|4|djmitche|Merge pull request #180 from djmitche/bug1508395  Bug 1508395 - upgrade tc-lib-validate|[URL](https://github.com/taskcluster/taskcluster-auth/commit/9ed089f62916fa2a54967379cfb5bc35156b8cea)|2018-11-21 19:48:44
+|3|djmitche|Merge pull request #182 from djmitche/bug1508849  Bug 1508849 - implement   -scope protection differently|[URL](https://github.com/taskcluster/taskcluster-auth/commit/052d624ea730559489f6984b8fb47b819e2ffe94)|2018-11-21 19:48:33
+|2|djmitche|Bug 1508849 - implement   -scope protection differently  The old solution used a negative lookbehind, which per https://json-schema.org/understanding-json-schema/reference/regular_expressions.html#regular-expressions is not supported in json-schema.  In fact, it's not supported in even fairly recent versions of Node.  This causes problems when validating schemas using those old versions of node (or using json-schema validators that do not support this form).  So, the new solution is to explicitly forbid those forms where used in creating clients and roles.  The result is much the same, as evidenced by the minimal changes to the tests.|[URL](https://github.com/taskcluster/taskcluster-auth/commit/b19103d6d2ac47d16e2086a283e04320651ff383)|2018-11-21 00:46:14
+|1|djmitche|Bug 1508395 - upgrade tc-lib-validate  The change ony affects the output of writeDocs.|[URL](https://github.com/taskcluster/taskcluster-auth/commit/e52d89a68dc312b5ca045558ff7d4011663312db)|2018-11-20 19:10:53
+
+

--- a/git_files/taskcluster-queue.json
+++ b/git_files/taskcluster-queue.json
@@ -1,0 +1,110 @@
+{
+  "0": {
+    "lastChecked": "2018-11-25 14:05:26.254789"
+  },
+  "1": {
+    "sha": "5f259488c4ea8bd43a15fa4c5f1b660c2ce887da",
+    "url": "https://github.com/taskcluster/taskcluster-queue/commit/5f259488c4ea8bd43a15fa4c5f1b660c2ce887da",
+    "commiter_name": "djmitche",
+    "commiter_email": "dustin@v.igoro.us",
+    "commit_message": "Bug 1508846 - upgrade tc-lib-api",
+    "commit_date": "2018-11-21 21:35:58",
+    "files_changed": [
+      "package.json",
+      "src/api.js",
+      "yarn.lock"
+    ]
+  },
+  "2": {
+    "sha": "ee3bef79dc9bb2726dd8cea644ad3290da60d3d4",
+    "url": "https://github.com/taskcluster/taskcluster-queue/commit/ee3bef79dc9bb2726dd8cea644ad3290da60d3d4",
+    "commiter_name": "djmitche",
+    "commiter_email": null,
+    "commit_message": "Merge pull request #299 from djmitche/bug1508395  Bug 1508395 - upgrade tc-lib-validate",
+    "commit_date": "2018-11-21 21:34:10",
+    "files_changed": [
+      "package.json",
+      "yarn.lock"
+    ]
+  },
+  "3": {
+    "sha": "087cca55ada7a151518f018819b1a21f59df769d",
+    "url": "https://github.com/taskcluster/taskcluster-queue/commit/087cca55ada7a151518f018819b1a21f59df769d",
+    "commiter_name": "djmitche",
+    "commiter_email": null,
+    "commit_message": "Merge branch 'master' into bug1508395",
+    "commit_date": "2018-11-21 21:34:04",
+    "files_changed": [
+      "package.json",
+      "schemas/constants.yml",
+      "src/api.js",
+      "src/exchanges.js",
+      "test/createtask_test.js",
+      "yarn.lock"
+    ]
+  },
+  "4": {
+    "sha": "6340fc2bafc194872799e59b55a37a7c54dd63b6",
+    "url": "https://github.com/taskcluster/taskcluster-queue/commit/6340fc2bafc194872799e59b55a37a7c54dd63b6",
+    "commiter_name": "djmitche",
+    "commiter_email": null,
+    "commit_message": "Merge pull request #300 from djmitche/bug1505405  Bug 1505405 - upgrade tc-lib-pulse",
+    "commit_date": "2018-11-21 21:33:36",
+    "files_changed": [
+      "package.json",
+      "src/exchanges.js",
+      "yarn.lock"
+    ]
+  },
+  "5": {
+    "sha": "17bf8649dabb96c849f2b875c82ad02fdf0d14ff",
+    "url": "https://github.com/taskcluster/taskcluster-queue/commit/17bf8649dabb96c849f2b875c82ad02fdf0d14ff",
+    "commiter_name": "djmitche",
+    "commiter_email": "dustin@v.igoro.us",
+    "commit_message": "Bug 1505405 - upgrade tc-lib-pulse",
+    "commit_date": "2018-11-20 20:24:55",
+    "files_changed": [
+      "package.json",
+      "src/exchanges.js",
+      "yarn.lock"
+    ]
+  },
+  "6": {
+    "sha": "bed26fb8855ee4c96174be3f9200cf4965f75a1d",
+    "url": "https://github.com/taskcluster/taskcluster-queue/commit/bed26fb8855ee4c96174be3f9200cf4965f75a1d",
+    "commiter_name": "djmitche",
+    "commiter_email": null,
+    "commit_message": "Merge pull request #301 from djmitche/bug1508849  Bug 1508849 - implement   -scope protection differently",
+    "commit_date": "2018-11-21 21:32:11",
+    "files_changed": [
+      "schemas/constants.yml",
+      "src/api.js",
+      "test/createtask_test.js"
+    ]
+  },
+  "7": {
+    "sha": "936be6b0b42002fbae57b69a6b4f7acabf82d8ac",
+    "url": "https://github.com/taskcluster/taskcluster-queue/commit/936be6b0b42002fbae57b69a6b4f7acabf82d8ac",
+    "commiter_name": "djmitche",
+    "commiter_email": "dustin@v.igoro.us",
+    "commit_message": "Bug 1508849 - implement   -scope protection differently  The old solution used a negative lookbehind, which per https://json-schema.org/understanding-json-schema/reference/regular_expressions.html#regular-expressions is not supported in json-schema. In fact, it's not supported in even fairly recent versions of Node. This causes problems when validating schemas using those old versions of node (or using json-schema validators that do not support this form).  So, the new solution is to explicitly forbid those forms where used in creating clients and roles. The result is much the same, as evidenced by the minimal changes to the tests.",
+    "commit_date": "2018-11-21 00:55:08",
+    "files_changed": [
+      "schemas/constants.yml",
+      "src/api.js",
+      "test/createtask_test.js"
+    ]
+  },
+  "8": {
+    "sha": "54344d0e797e7338f88dadca4627846648200c36",
+    "url": "https://github.com/taskcluster/taskcluster-queue/commit/54344d0e797e7338f88dadca4627846648200c36",
+    "commiter_name": "djmitche",
+    "commiter_email": "dustin@v.igoro.us",
+    "commit_message": "Bug 1508395 - upgrade tc-lib-validate  This should only affect writeDocs",
+    "commit_date": "2018-11-20 20:22:31",
+    "files_changed": [
+      "package.json",
+      "yarn.lock"
+    ]
+  }
+}

--- a/git_files/taskcluster-queue.md
+++ b/git_files/taskcluster-queue.md
@@ -1,0 +1,14 @@
+## TASKCLUSTER-QUEUE COMMIT MARKDOWN TABLE SINCE 2018-11-18 16:03:59.730188
+
+| Commit Number | Commiter | Commit Message | Commit Url | Date | 
+|:---:|:----:|:----------------------------------:|:------:|:----:| 
+|8|djmitche|Bug 1508846 - upgrade tc-lib-api|[URL](https://github.com/taskcluster/taskcluster-queue/commit/5f259488c4ea8bd43a15fa4c5f1b660c2ce887da)|2018-11-21 21:35:58
+|7|djmitche|Merge pull request #299 from djmitche/bug1508395  Bug 1508395 - upgrade tc-lib-validate|[URL](https://github.com/taskcluster/taskcluster-queue/commit/ee3bef79dc9bb2726dd8cea644ad3290da60d3d4)|2018-11-21 21:34:10
+|6|djmitche|Merge branch 'master' into bug1508395|[URL](https://github.com/taskcluster/taskcluster-queue/commit/087cca55ada7a151518f018819b1a21f59df769d)|2018-11-21 21:34:04
+|5|djmitche|Merge pull request #300 from djmitche/bug1505405  Bug 1505405 - upgrade tc-lib-pulse|[URL](https://github.com/taskcluster/taskcluster-queue/commit/6340fc2bafc194872799e59b55a37a7c54dd63b6)|2018-11-21 21:33:36
+|4|djmitche|Bug 1505405 - upgrade tc-lib-pulse|[URL](https://github.com/taskcluster/taskcluster-queue/commit/17bf8649dabb96c849f2b875c82ad02fdf0d14ff)|2018-11-20 20:24:55
+|3|djmitche|Merge pull request #301 from djmitche/bug1508849  Bug 1508849 - implement   -scope protection differently|[URL](https://github.com/taskcluster/taskcluster-queue/commit/bed26fb8855ee4c96174be3f9200cf4965f75a1d)|2018-11-21 21:32:11
+|2|djmitche|Bug 1508849 - implement   -scope protection differently  The old solution used a negative lookbehind, which per https://json-schema.org/understanding-json-schema/reference/regular_expressions.html#regular-expressions is not supported in json-schema. In fact, it's not supported in even fairly recent versions of Node. This causes problems when validating schemas using those old versions of node (or using json-schema validators that do not support this form).  So, the new solution is to explicitly forbid those forms where used in creating clients and roles. The result is much the same, as evidenced by the minimal changes to the tests.|[URL](https://github.com/taskcluster/taskcluster-queue/commit/936be6b0b42002fbae57b69a6b4f7acabf82d8ac)|2018-11-21 00:55:08
+|1|djmitche|Bug 1508395 - upgrade tc-lib-validate  This should only affect writeDocs|[URL](https://github.com/taskcluster/taskcluster-queue/commit/54344d0e797e7338f88dadca4627846648200c36)|2018-11-20 20:22:31
+
+

--- a/repositories.json
+++ b/repositories.json
@@ -4,11 +4,22 @@
       "name": "Ship It",
       "url": "https://github.com/mozilla-releng/ship-it",
       "team": "mozilla-releng/",
-      "top-contributors": [" ", " "],
+      "top-contributors": [
+        " ",
+        " "
+      ],
       "configuration": {
         "type": " ",
-        "folders-to-ignore": [" ", " ", " "],
-        "files-to-ignore": [" ", " ", " "],
+        "folders-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
+        "files-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
         "release-path": " "
       }
     },
@@ -16,11 +27,22 @@
       "name": "Release Services",
       "url": "https://github.com/mozilla/release-services",
       "team": "mozilla/",
-      "top-contributors": [" ", " "],
+      "top-contributors": [
+        " ",
+        " "
+      ],
       "configuration": {
         "type": " ",
-        "folders-to-ignore": [" ", " ", " "],
-        "files-to-ignore": [" ", " ", " "],
+        "folders-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
+        "files-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
         "release-path": " "
       }
     },
@@ -28,11 +50,22 @@
       "name": "Beet Mover Script",
       "url": "https://github.com/mozilla-releng/beetmoverscript",
       "team": "mozilla-releng/",
-      "top-contributors": [" ", " "],
+      "top-contributors": [
+        " ",
+        " "
+      ],
       "configuration": {
         "type": " ",
-        "folders-to-ignore": [" ", " ", " "],
-        "files-to-ignore": [" ", " ", " "],
+        "folders-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
+        "files-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
         "release-path": " "
       }
     },
@@ -40,11 +73,22 @@
       "name": "Addon Script",
       "url": "https://github.com/mozilla-releng/addonscript",
       "team": "mozilla-releng/",
-      "top-contributors": [" ", " "],
+      "top-contributors": [
+        " ",
+        " "
+      ],
       "configuration": {
         "type": " ",
-        "folders-to-ignore": [" ", " ", " "],
-        "files-to-ignore": [" ", " ", " "],
+        "folders-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
+        "files-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
         "release-path": " "
       }
     },
@@ -52,11 +96,22 @@
       "name": "Build Cloud Tools",
       "url": "https://github.com/mozilla-releng/build-cloud-tools",
       "team": "mozilla-releng/",
-      "top-contributors": [" ", " "],
+      "top-contributors": [
+        " ",
+        " "
+      ],
       "configuration": {
         "type": " ",
-        "folders-to-ignore": [" ", " ", " "],
-        "files-to-ignore": [" ", " ", " "],
+        "folders-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
+        "files-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
         "release-path": " "
       }
     },
@@ -64,11 +119,22 @@
       "name": "Build Puppet",
       "url": "https://github.com/mozilla/build-puppet",
       "team": "mozilla/",
-      "top-contributors": [" ", " "],
+      "top-contributors": [
+        " ",
+        " "
+      ],
       "configuration": {
         "type": " ",
-        "folders-to-ignore": [" ", " ", " "],
-        "files-to-ignore": [" ", " ", " "],
+        "folders-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
+        "files-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
         "release-path": " "
       }
     },
@@ -76,11 +142,22 @@
       "name": "Shipit Script",
       "url": "https://github.com/mozilla-releng/shipitscript",
       "team": "mozilla-releng/",
-      "top-contributors": [" ", " "],
+      "top-contributors": [
+        " ",
+        " "
+      ],
       "configuration": {
         "type": " ",
-        "folders-to-ignore": [" ", " ", " "],
-        "files-to-ignore": [" ", " ", " "],
+        "folders-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
+        "files-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
         "release-path": " "
       }
     },
@@ -88,11 +165,22 @@
       "name": "Bouncer Script",
       "url": "https://github.com/mozilla-releng/bouncerscript",
       "team": "mozilla-releng/",
-      "top-contributors": [" ", " "],
+      "top-contributors": [
+        " ",
+        " "
+      ],
       "configuration": {
         "type": " ",
-        "folders-to-ignore": [" ", " ", " "],
-        "files-to-ignore": [" ", " ", " "],
+        "folders-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
+        "files-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
         "release-path": " "
       }
     },
@@ -100,11 +188,22 @@
       "name": "Tree Script",
       "url": "https://github.com/mozilla-releng/treescript",
       "team": "mozilla-releng/",
-      "top-contributors": [" ", " "],
+      "top-contributors": [
+        " ",
+        " "
+      ],
       "configuration": {
         "type": " ",
-        "folders-to-ignore": [" ", " ", " "],
-        "files-to-ignore": [" ", " ", " "],
+        "folders-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
+        "files-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
         "release-path": " "
       }
     },
@@ -112,11 +211,22 @@
       "name": "MozAPK Publisher",
       "url": "https://github.com/mozilla-releng/mozapkpublisher",
       "team": "mozilla-releng/",
-      "top-contributors": [" ", " "],
+      "top-contributors": [
+        " ",
+        " "
+      ],
       "configuration": {
         "type": " ",
-        "folders-to-ignore": [" ", " ", " "],
-        "files-to-ignore": [" ", " ", " "],
+        "folders-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
+        "files-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
         "release-path": " "
       }
     },
@@ -124,11 +234,22 @@
       "name": "Open Cloud Config",
       "url": "https://github.com/mozilla-releng/OpenCloudConfig",
       "team": "mozilla-releng/",
-      "top-contributors": [" ", " "],
+      "top-contributors": [
+        " ",
+        " "
+      ],
       "configuration": {
         "type": " ",
-        "folders-to-ignore": [" ", " ", " "],
-        "files-to-ignore": [" ", " ", " "],
+        "folders-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
+        "files-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
         "release-path": " "
       }
     },
@@ -136,11 +257,22 @@
       "name": "Script Worker",
       "url": "https://github.com/mozilla-releng/scriptworker",
       "team": "mozilla-releng/",
-      "top-contributors": [" ", " "],
+      "top-contributors": [
+        " ",
+        " "
+      ],
       "configuration": {
         "type": " ",
-        "folders-to-ignore": [" ", " ", " "],
-        "files-to-ignore": [" ", " ", " "],
+        "folders-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
+        "files-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
         "release-path": " "
       }
     },
@@ -148,11 +280,22 @@
       "name": "Push Snap Script",
       "url": "https://github.com/mozilla-releng/pushsnapscript",
       "team": "mozilla-releng/",
-      "top-contributors": [" ", " "],
+      "top-contributors": [
+        " ",
+        " "
+      ],
       "configuration": {
         "type": " ",
-        "folders-to-ignore": [" ", " ", " "],
-        "files-to-ignore": [" ", " ", " "],
+        "folders-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
+        "files-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
         "release-path": " "
       }
     },
@@ -160,11 +303,22 @@
       "name": "Sign Script",
       "url": "https://github.com/mozilla-releng/signingscript",
       "team": "mozilla-releng/",
-      "top-contributors": [" ", " "],
+      "top-contributors": [
+        " ",
+        " "
+      ],
       "configuration": {
         "type": " ",
-        "folders-to-ignore": [" ", " ", " "],
-        "files-to-ignore": [" ", " ", " "],
+        "folders-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
+        "files-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
         "release-path": " "
       }
     },
@@ -172,11 +326,22 @@
       "name": "PushAPK Script",
       "url": "https://github.com/mozilla-releng/pushapkscript",
       "team": "mozilla-releng/",
-      "top-contributors": [" ", " "],
+      "top-contributors": [
+        " ",
+        " "
+      ],
       "configuration": {
         "type": " ",
-        "folders-to-ignore": [" ", " ", " "],
-        "files-to-ignore": [" ", " ", " "],
+        "folders-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
+        "files-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
         "release-path": " "
       }
     },
@@ -184,11 +349,22 @@
       "name": "Balrog Script",
       "url": "https://github.com/mozilla-releng/balrogscript",
       "team": "mozilla-releng/",
-      "top-contributors": [" ", " "],
+      "top-contributors": [
+        " ",
+        " "
+      ],
       "configuration": {
         "type": " ",
-        "folders-to-ignore": [" ", " ", " "],
-        "files-to-ignore": [" ", " ", " "],
+        "folders-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
+        "files-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
         "release-path": " "
       }
     },
@@ -196,11 +372,68 @@
       "name": "Sign Tool",
       "url": "https://github.com/mozilla-releng/signtool",
       "team": "mozilla-releng/",
-      "top-contributors": [" ", " "],
+      "top-contributors": [
+        " ",
+        " "
+      ],
       "configuration": {
         "type": " ",
-        "folders-to-ignore": [" ", " ", " "],
-        "files-to-ignore": [" ", " ", " "],
+        "folders-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
+        "files-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
+        "release-path": " "
+      }
+    },
+    "taskcluster-auth": {
+      "name": "Taskcluster Auth",
+      "url": "https://github.com/taskcluster/taskcluster-auth",
+      "team": "taskcluster/",
+      "top-contributors": [
+        " ",
+        " "
+      ],
+      "configuration": {
+        "type": " ",
+        "folders-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
+        "files-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
+        "release-path": " "
+      }
+    },
+    "taskcluster-queue": {
+      "name": "Taskcluster Queue",
+      "url": "https://github.com/taskcluster/taskcluster-queue",
+      "team": "taskcluster/",
+      "top-contributors": [
+        " ",
+        " "
+      ],
+      "configuration": {
+        "type": " ",
+        "folders-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
+        "files-to-ignore": [
+          " ",
+          " ",
+          " "
+        ],
         "release-path": " "
       }
     }
@@ -362,5 +595,5 @@
         "push_type": "json-log"
       }
      }
-   }
+  }
 }


### PR DESCRIPTION
Added a parameter for create_files_for_hg and create_files_for_git functions because:
- the repositories variable wasn't referenced anymore in the main function 
- someone looking at the code for the first time wouldn't understand how and where this var was used 
- this way it is clearer and easier to understand the flow of the logic. 
- It also allows us to call the 2 aforementioned def's on any json file that has a repo list

Added taskcluster-auth and taskcluster-queue to the git repo list in repositories.json
The script successfully generates the json and MD files for these 2 repos.


