### PR TITLE
Change the markdown header for the repositories with release tags

### DIFF
--- a/client.py
+++ b/client.py
@@ -234,7 +234,12 @@ def create_md_table(repository_name, path_to_files):
         base_table = "| Commit Number | Commiter | Commit Message | Commit Url | Date | \n" + \
                      "|:---:|:----:|:----------------------------------:|:------:|:----:| \n"
         tables = {}
-        md_title = ["{} commit markdown table since {}".format(repository_name, lastWeek)]
+        try:
+            version = data['0']["last_two_releases"]["LatestRelease"]["version"]
+            date = data['0']["last_two_releases"]["LatestRelease"]["date"]
+            md_title = ["Repository name: {}\n Current version: {} released on {}".format(repository_name, version, date)]
+        except:
+            md_title = ["{} commit markdown table since {}".format(repository_name, lastWeek)]
         commit_number_list = [key for key in data]
 
         for repo in md_title:
@@ -260,7 +265,7 @@ def create_md_table(repository_name, path_to_files):
                 for repo in tables.keys():
                     tables[repo] = tables[repo] + row
             except KeyError:
-                last_checked = data[key]["lastChecked"]
+                pass
 
         md_file_name = "{}.md".format(repository_name)
         md_file = open(current_dir + "/{}/".format(path_to_files) + md_file_name, "w")

--- a/git_files/OpenCloudConfig.json
+++ b/git_files/OpenCloudConfig.json
@@ -1,6 +1,6 @@
 {
   "0": {
-    "lastChecked": "2018-12-03 19:46:02.546728",
+    "lastChecked": "2018-12-05 01:51:36.632259",
     "last_two_releases": null
   },
   "1": {
@@ -45,102 +45,6 @@
       "userdata/Manifest/gecko-t-win10-64-hw.json",
       "userdata/Manifest/gecko-t-win10-64-ux.json",
       "userdata/Manifest/gecko-t-win10-64.json"
-    ]
-  },
-  "5": {
-    "sha": "c421eb84b254a74a84916ad5bd1d957bea060f33",
-    "url": "https://github.com/mozilla-releng/OpenCloudConfig/commit/c421eb84b254a74a84916ad5bd1d957bea060f33",
-    "commiter_name": "grenade",
-    "commiter_email": "rthijssen@gmail.com",
-    "commit_message": "Bug 1510220 - defer upgrades in registry  deploy: gecko-t-win10-64 gecko-t-win10-64-gpu",
-    "commit_date": "2018-11-27 13:39:44",
-    "files_changed": [
-      "userdata/Manifest/gecko-t-win10-64-gpu.json",
-      "userdata/Manifest/gecko-t-win10-64.json"
-    ]
-  },
-  "6": {
-    "sha": "0952e36cbab072488f1bea41d1095a13063c705e",
-    "url": "https://github.com/mozilla-releng/OpenCloudConfig/commit/0952e36cbab072488f1bea41d1095a13063c705e",
-    "commiter_name": "grenade",
-    "commiter_email": "rthijssen@gmail.com",
-    "commit_message": "Bug 1509722 - correction to run-userdata ec2config setting  deploy: gecko-t-win10-64 gecko-t-win10-64-gpu",
-    "commit_date": "2018-11-27 12:53:44",
-    "files_changed": [
-      "userdata/OCC-Bootstrap.psm1"
-    ]
-  },
-  "7": {
-    "sha": "7ead7d21328907a108fb6bd228fef28c700d60c6",
-    "url": "https://github.com/mozilla-releng/OpenCloudConfig/commit/7ead7d21328907a108fb6bd228fef28c700d60c6",
-    "commiter_name": "grenade",
-    "commiter_email": "rthijssen@gmail.com",
-    "commit_message": "Bug 1509722 - shorter match string  on some os's the transcript line length is truncated at row 80, causing occasional failure to match longer strings that contain a newline  deploy: gecko-t-win10-64 gecko-t-win10-64-gpu",
-    "commit_date": "2018-11-27 11:56:39",
-    "files_changed": [
-      "userdata/OCC-Bootstrap.psm1"
-    ]
-  },
-  "8": {
-    "sha": "07d3d6340f241e398fd91285363447e9dda0e47b",
-    "url": "https://github.com/mozilla-releng/OpenCloudConfig/commit/07d3d6340f241e398fd91285363447e9dda0e47b",
-    "commiter_name": "grenade",
-    "commiter_email": "rthijssen@gmail.com",
-    "commit_message": "Bug 1509722 - redeploy, prevent halt-on-idle shutdown  deploy: gecko-t-win10-64 gecko-t-win10-64-gpu",
-    "commit_date": "2018-11-27 10:28:52",
-    "files_changed": [
-      "userdata/HaltOnIdle.ps1"
-    ]
-  },
-  "9": {
-    "sha": "9af661f41e9085149b690fad872ea315f22ac2f7",
-    "url": "https://github.com/mozilla-releng/OpenCloudConfig/commit/9af661f41e9085149b690fad872ea315f22ac2f7",
-    "commiter_name": "grenade",
-    "commiter_email": "rthijssen@gmail.com",
-    "commit_message": "Bug - 1493688 add workertypes for 1803 testing  deploy: alpha",
-    "commit_date": "2018-11-27 10:10:57",
-    "files_changed": [
-      ".taskcluster.yml",
-      "ci/update-workertype.sh",
-      "userdata/Manifest/gecko-1-b-win2012-beta.json",
-      "userdata/Manifest/gecko-1-b-win2012.json",
-      "userdata/Manifest/gecko-2-b-win2012.json",
-      "userdata/Manifest/gecko-3-b-win2012-c4.json",
-      "userdata/Manifest/gecko-3-b-win2012-c5.json",
-      "userdata/Manifest/gecko-3-b-win2012.json",
-      "userdata/Manifest/gecko-t-win10-64-alpha.json",
-      "userdata/Manifest/gecko-t-win10-64-beta.json",
-      "userdata/Manifest/gecko-t-win10-64-cu.json",
-      "userdata/Manifest/gecko-t-win10-64-gpu-a.json",
-      "userdata/Manifest/gecko-t-win10-64-gpu-b.json",
-      "userdata/Manifest/gecko-t-win10-64-gpu.json",
-      "userdata/Manifest/gecko-t-win10-64.json",
-      "userdata/Manifest/gecko-t-win7-32-beta.json",
-      "userdata/Manifest/gecko-t-win7-32-cu.json",
-      "userdata/Manifest/gecko-t-win7-32-gpu-b.json",
-      "userdata/Manifest/gecko-t-win7-32-gpu.json",
-      "userdata/Manifest/gecko-t-win7-32.json",
-      "userdata/Manifest/relops-image-builder.json"
-    ]
-  },
-  "10": {
-    "sha": "822e71bff955f714d1d318dc2b0483ca672e2e53",
-    "url": "https://github.com/mozilla-releng/OpenCloudConfig/commit/822e71bff955f714d1d318dc2b0483ca672e2e53",
-    "commiter_name": "grenade",
-    "commiter_email": null,
-    "commit_message": " Bug 1509722 - disable windows defender & supporting services (#215)  disable: wscsvc, SecurityHealthService, Sense; manual: WdBoot, WdFilter, WdNisDrv, WdNisSvc, WinDefend, boot loop until all disables are successful.  deploy: gecko-t-win10-64 gecko-t-win10-64-gpu",
-    "commit_date": "2018-11-27 09:16:58",
-    "files_changed": [
-      "readme.md",
-      "userdata/Manifest/gecko-t-win10-64-beta.json",
-      "userdata/Manifest/gecko-t-win10-64-cu.json",
-      "userdata/Manifest/gecko-t-win10-64-gpu-b.json",
-      "userdata/Manifest/gecko-t-win10-64-gpu.json",
-      "userdata/Manifest/gecko-t-win10-64-hw.json",
-      "userdata/Manifest/gecko-t-win10-64-ux.json",
-      "userdata/Manifest/gecko-t-win10-64.json",
-      "userdata/OCC-Bootstrap.psm1",
-      "userdata/xDynamicConfig.ps1"
     ]
   }
 }

--- a/git_files/OpenCloudConfig.md
+++ b/git_files/OpenCloudConfig.md
@@ -1,16 +1,10 @@
-## OPENCLOUDCONFIG COMMIT MARKDOWN TABLE SINCE 2018-11-26 21:45:13.184847
+## OPENCLOUDCONFIG COMMIT MARKDOWN TABLE SINCE 2018-11-28 03:50:58.773984
 
 | Commit Number | Commiter | Commit Message | Commit Url | Date | 
 |:---:|:----:|:----------------------------------:|:------:|:----:| 
-|10|grenade|Bug 1485628 - disable service pack updates & reboots  deploy: gecko-t-win10-64 gecko-t-win10-64-gpu|[URL](https://github.com/mozilla-releng/OpenCloudConfig/commit/4053e2c3c0db9b63ff74ca32c9bb6c14ccc4f08a)|2018-11-28 17:27:08
-|9|grenade|Bug 1485628 - disable service pack updates & reboots  deploy: gecko-t-win10-64 gecko-t-win10-64-gpu|[URL](https://github.com/mozilla-releng/OpenCloudConfig/commit/bbdfd298d8fed84fab86e30d4322b365fb01a604)|2018-11-28 17:18:59
-|8|grenade|Bug 1485628 - disable service pack updates & reboots  deploy: gecko-t-win10-64 gecko-t-win10-64-gpu|[URL](https://github.com/mozilla-releng/OpenCloudConfig/commit/bcb4c6ddd1c4efdc7fc07eb079b934e7a76ca12d)|2018-11-28 17:10:22
-|7|grenade|Bug 1485628 - disable service pack updates & reboots (#216)  deploy: gecko-t-win10-64 gecko-t-win10-64-gpu|[URL](https://github.com/mozilla-releng/OpenCloudConfig/commit/3c874a7b7ab236ec1939728b43451e44eb50ff6f)|2018-11-28 17:08:20
-|6|grenade|Bug 1510220 - defer upgrades in registry  deploy: gecko-t-win10-64 gecko-t-win10-64-gpu|[URL](https://github.com/mozilla-releng/OpenCloudConfig/commit/c421eb84b254a74a84916ad5bd1d957bea060f33)|2018-11-27 13:39:44
-|5|grenade|Bug 1509722 - correction to run-userdata ec2config setting  deploy: gecko-t-win10-64 gecko-t-win10-64-gpu|[URL](https://github.com/mozilla-releng/OpenCloudConfig/commit/0952e36cbab072488f1bea41d1095a13063c705e)|2018-11-27 12:53:44
-|4|grenade|Bug 1509722 - shorter match string  on some os's the transcript line length is truncated at row 80, causing occasional failure to match longer strings that contain a newline  deploy: gecko-t-win10-64 gecko-t-win10-64-gpu|[URL](https://github.com/mozilla-releng/OpenCloudConfig/commit/7ead7d21328907a108fb6bd228fef28c700d60c6)|2018-11-27 11:56:39
-|3|grenade|Bug 1509722 - redeploy, prevent halt-on-idle shutdown  deploy: gecko-t-win10-64 gecko-t-win10-64-gpu|[URL](https://github.com/mozilla-releng/OpenCloudConfig/commit/07d3d6340f241e398fd91285363447e9dda0e47b)|2018-11-27 10:28:52
-|2|grenade|Bug - 1493688 add workertypes for 1803 testing  deploy: alpha|[URL](https://github.com/mozilla-releng/OpenCloudConfig/commit/9af661f41e9085149b690fad872ea315f22ac2f7)|2018-11-27 10:10:57
-|1|grenade| Bug 1509722 - disable windows defender & supporting services (#215)  disable: wscsvc, SecurityHealthService, Sense; manual: WdBoot, WdFilter, WdNisDrv, WdNisSvc, WinDefend, boot loop until all disables are successful.  deploy: gecko-t-win10-64 gecko-t-win10-64-gpu|[URL](https://github.com/mozilla-releng/OpenCloudConfig/commit/822e71bff955f714d1d318dc2b0483ca672e2e53)|2018-11-27 09:16:58
+|4|grenade|Bug 1485628 - disable service pack updates & reboots  deploy: gecko-t-win10-64 gecko-t-win10-64-gpu|[URL](https://github.com/mozilla-releng/OpenCloudConfig/commit/4053e2c3c0db9b63ff74ca32c9bb6c14ccc4f08a)|2018-11-28 17:27:08
+|3|grenade|Bug 1485628 - disable service pack updates & reboots  deploy: gecko-t-win10-64 gecko-t-win10-64-gpu|[URL](https://github.com/mozilla-releng/OpenCloudConfig/commit/bbdfd298d8fed84fab86e30d4322b365fb01a604)|2018-11-28 17:18:59
+|2|grenade|Bug 1485628 - disable service pack updates & reboots  deploy: gecko-t-win10-64 gecko-t-win10-64-gpu|[URL](https://github.com/mozilla-releng/OpenCloudConfig/commit/bcb4c6ddd1c4efdc7fc07eb079b934e7a76ca12d)|2018-11-28 17:10:22
+|1|grenade|Bug 1485628 - disable service pack updates & reboots (#216)  deploy: gecko-t-win10-64 gecko-t-win10-64-gpu|[URL](https://github.com/mozilla-releng/OpenCloudConfig/commit/3c874a7b7ab236ec1939728b43451e44eb50ff6f)|2018-11-28 17:08:20
 
 

--- a/git_files/addonscript.md
+++ b/git_files/addonscript.md
@@ -1,4 +1,5 @@
-## ADDONSCRIPT COMMIT MARKDOWN TABLE SINCE 2018-11-26 21:45:13.184847
+## REPOSITORY NAME: ADDONSCRIPT
+ CURRENT VERSION: 1.0 RELEASED ON THU, 17 MAY 2018 13:58:03 GMT
 
 | Commit Number | Commiter | Commit Message | Commit Url | Date | 
 |:---:|:----:|:----------------------------------:|:------:|:----:| 

--- a/git_files/balrogscript.md
+++ b/git_files/balrogscript.md
@@ -1,4 +1,5 @@
-## BALROGSCRIPT COMMIT MARKDOWN TABLE SINCE 2018-11-26 21:45:13.184847
+## REPOSITORY NAME: BALROGSCRIPT
+ CURRENT VERSION: 3.3.0 RELEASED ON MON, 26 NOV 2018 17:29:44 GMT
 
 | Commit Number | Commiter | Commit Message | Commit Url | Date | 
 |:---:|:----:|:----------------------------------:|:------:|:----:| 

--- a/git_files/beetmoverscript.md
+++ b/git_files/beetmoverscript.md
@@ -1,4 +1,5 @@
-## BEETMOVERSCRIPT COMMIT MARKDOWN TABLE SINCE 2018-11-26 21:45:13.184847
+## REPOSITORY NAME: BEETMOVERSCRIPT
+ CURRENT VERSION: 8.0.0 RELEASED ON WED, 28 NOV 2018 01:08:55 GMT
 
 | Commit Number | Commiter | Commit Message | Commit Url | Date | 
 |:---:|:----:|:----------------------------------:|:------:|:----:| 

--- a/git_files/bouncerscript.md
+++ b/git_files/bouncerscript.md
@@ -1,4 +1,5 @@
-## BOUNCERSCRIPT COMMIT MARKDOWN TABLE SINCE 2018-11-26 21:45:13.184847
+## REPOSITORY NAME: BOUNCERSCRIPT
+ CURRENT VERSION: 3.3.0 RELEASED ON MON, 12 NOV 2018 16:20:14 GMT
 
 | Commit Number | Commiter | Commit Message | Commit Url | Date | 
 |:---:|:----:|:----------------------------------:|:------:|:----:| 

--- a/git_files/build-cloud-tools.json
+++ b/git_files/build-cloud-tools.json
@@ -1,26 +1,37 @@
 {
   "0": {
-    "lastChecked": "2018-12-03 19:45:29.854677",
+    "lastChecked": "2018-12-05 01:51:13.655575",
     "last_two_releases": null
   },
   "1": {
+    "sha": "3962e62c72251ae9fc531bdb5b14ba40243a5b70",
+    "url": "https://github.com/mozilla-releng/build-cloud-tools/commit/3962e62c72251ae9fc531bdb5b14ba40243a5b70",
+    "commiter_name": "dividehex",
+    "commiter_email": null,
+    "commit_message": "Merge branch 'La0-buildhub-cert'",
+    "commit_date": "2018-12-04 16:30:17",
+    "files_changed": [
+      "terraform/base/route53.tf"
+    ]
+  },
+  "2": {
+    "sha": "7fe44bf80d48b949c4d65c7642e3e4b69780af84",
+    "url": "https://github.com/mozilla-releng/build-cloud-tools/commit/7fe44bf80d48b949c4d65c7642e3e4b69780af84",
+    "commiter_name": "La0",
+    "commiter_email": "bastien@nextcairn.com",
+    "commit_message": "Add CNAME record for DigiCert on buildhub.moz.tools",
+    "commit_date": "2018-12-04 15:48:33",
+    "files_changed": [
+      "terraform/base/route53.tf"
+    ]
+  },
+  "3": {
     "sha": "cb2ede208a3dda6df742eb0f251827762931f1d1",
     "url": "https://github.com/mozilla-releng/build-cloud-tools/commit/cb2ede208a3dda6df742eb0f251827762931f1d1",
     "commiter_name": "dividehex",
     "commiter_email": null,
     "commit_message": "Merge branch 'La0-buildhub'",
     "commit_date": "2018-11-29 02:03:48",
-    "files_changed": [
-      "terraform/base/route53.tf"
-    ]
-  },
-  "2": {
-    "sha": "62d5a4b0cf4c9d52836bc196680cca8ca08a4d53",
-    "url": "https://github.com/mozilla-releng/build-cloud-tools/commit/62d5a4b0cf4c9d52836bc196680cca8ca08a4d53",
-    "commiter_name": "La0",
-    "commiter_email": "bastien@nextcairn.com",
-    "commit_message": "Add CNAME for buildhub.moz.tools",
-    "commit_date": "2018-11-27 09:13:51",
     "files_changed": [
       "terraform/base/route53.tf"
     ]

--- a/git_files/build-cloud-tools.md
+++ b/git_files/build-cloud-tools.md
@@ -1,8 +1,9 @@
-## BUILD-CLOUD-TOOLS COMMIT MARKDOWN TABLE SINCE 2018-11-26 21:45:13.184847
+## BUILD-CLOUD-TOOLS COMMIT MARKDOWN TABLE SINCE 2018-11-28 03:50:58.773984
 
 | Commit Number | Commiter | Commit Message | Commit Url | Date | 
 |:---:|:----:|:----------------------------------:|:------:|:----:| 
-|2|dividehex|Merge branch 'La0-buildhub'|[URL](https://github.com/mozilla-releng/build-cloud-tools/commit/cb2ede208a3dda6df742eb0f251827762931f1d1)|2018-11-29 02:03:48
-|1|La0|Add CNAME for buildhub.moz.tools|[URL](https://github.com/mozilla-releng/build-cloud-tools/commit/62d5a4b0cf4c9d52836bc196680cca8ca08a4d53)|2018-11-27 09:13:51
+|3|dividehex|Merge branch 'La0-buildhub-cert'|[URL](https://github.com/mozilla-releng/build-cloud-tools/commit/3962e62c72251ae9fc531bdb5b14ba40243a5b70)|2018-12-04 16:30:17
+|2|La0|Add CNAME record for DigiCert on buildhub.moz.tools|[URL](https://github.com/mozilla-releng/build-cloud-tools/commit/7fe44bf80d48b949c4d65c7642e3e4b69780af84)|2018-12-04 15:48:33
+|1|dividehex|Merge branch 'La0-buildhub'|[URL](https://github.com/mozilla-releng/build-cloud-tools/commit/cb2ede208a3dda6df742eb0f251827762931f1d1)|2018-11-29 02:03:48
 
 

--- a/git_files/build-puppet.json
+++ b/git_files/build-puppet.json
@@ -1,6 +1,6 @@
 {
   "0": {
-    "lastChecked": "2018-12-03 19:45:32.383680",
+    "lastChecked": "2018-12-05 01:51:15.648031",
     "last_two_releases": null
   },
   "1": {
@@ -329,92 +329,6 @@
     "commit_date": "2018-11-28 09:53:35",
     "files_changed": [
       "modules/beetmover_scriptworker/files/requirements.txt"
-    ]
-  },
-  "29": {
-    "sha": "2aef9521b2bfabde8cbbd2e8388dab84b017f5ca",
-    "url": "https://github.com/mozilla-releng/build-puppet/commit/2aef9521b2bfabde8cbbd2e8388dab84b017f5ca",
-    "commiter_name": "MihaiTabara",
-    "commiter_email": "tabara.mihai@gmail.com",
-    "commit_message": "Bump beetmoverscript in beetmoverworkers.",
-    "commit_date": "2018-11-28 01:11:53",
-    "files_changed": [
-      "modules/beetmover_scriptworker/files/requirements.txt"
-    ]
-  },
-  "30": {
-    "sha": "4d55efd50ee5b9ca6f6d1e2c76bd11ed503918c7",
-    "url": "https://github.com/mozilla-releng/build-puppet/commit/4d55efd50ee5b9ca6f6d1e2c76bd11ed503918c7",
-    "commiter_name": "mitchhentges",
-    "commiter_email": "mitch9654@gmail.com",
-    "commit_message": "Adds mobile-dep pushapk env config",
-    "commit_date": "2018-11-28 00:04:27",
-    "files_changed": [
-      "modules/pushapk_scriptworker/manifests/settings.pp"
-    ]
-  },
-  "31": {
-    "sha": "bfeb4b9b7a7931e277c607283e99f9c5c323fb28",
-    "url": "https://github.com/mozilla-releng/build-puppet/commit/bfeb4b9b7a7931e277c607283e99f9c5c323fb28",
-    "commiter_name": "tomprince",
-    "commiter_email": null,
-    "commit_message": "Merge pull request #311 from tp-tc/scriptworker-cron  Bump scriptworker to 17.0.0 for push information in cron tasks.",
-    "commit_date": "2018-11-27 21:24:14",
-    "files_changed": [
-      "modules/addon_scriptworker/files/requirements.txt",
-      "modules/balrog_scriptworker/files/requirements-3.txt",
-      "modules/beetmover_scriptworker/files/requirements.txt",
-      "modules/bouncer_scriptworker/files/requirements.txt",
-      "modules/pushapk_scriptworker/files/requirements.txt",
-      "modules/shipit_scriptworker/files/requirements.txt",
-      "modules/signing_scriptworker/files/requirements.txt",
-      "modules/transparency_scriptworker/files/requirements.txt",
-      "modules/tree_scriptworker/files/requirements.txt"
-    ]
-  },
-  "32": {
-    "sha": "08f05d12e2cae01c387e5ac0b19c3d78597828d2",
-    "url": "https://github.com/mozilla-releng/build-puppet/commit/08f05d12e2cae01c387e5ac0b19c3d78597828d2",
-    "commiter_name": "tomprince",
-    "commiter_email": "tom.prince@twistedmatrix.com",
-    "commit_message": "Bump scriptworker to 17.0.0 for push information in cron tasks.",
-    "commit_date": "2018-11-27 18:00:24",
-    "files_changed": [
-      "modules/addon_scriptworker/files/requirements.txt",
-      "modules/balrog_scriptworker/files/requirements-3.txt",
-      "modules/beetmover_scriptworker/files/requirements.txt",
-      "modules/bouncer_scriptworker/files/requirements.txt",
-      "modules/pushapk_scriptworker/files/requirements.txt",
-      "modules/shipit_scriptworker/files/requirements.txt",
-      "modules/signing_scriptworker/files/requirements.txt",
-      "modules/transparency_scriptworker/files/requirements.txt",
-      "modules/tree_scriptworker/files/requirements.txt"
-    ]
-  },
-  "33": {
-    "sha": "81815340e943aab9e886a3f6c799d58c101451ac",
-    "url": "https://github.com/mozilla-releng/build-puppet/commit/81815340e943aab9e886a3f6c799d58c101451ac",
-    "commiter_name": "tomprince",
-    "commiter_email": null,
-    "commit_message": "Merge pull request #309 from tp-tc/whats-new  Update balrogscript for WNP support.",
-    "commit_date": "2018-11-27 17:02:34",
-    "files_changed": [
-      "modules/balrog_scriptworker/files/requirements-27.txt",
-      "modules/balrog_scriptworker/manifests/init.pp"
-    ]
-  },
-  "34": {
-    "sha": "a198270e36c42b6541542d48f895c8479415b9b7",
-    "url": "https://github.com/mozilla-releng/build-puppet/commit/a198270e36c42b6541542d48f895c8479415b9b7",
-    "commiter_name": "mitchhentges",
-    "commiter_email": null,
-    "commit_message": "Merge pull request #303 from mitchhentges/bug1508508  Adds configuration for reference browser (prod and staging)",
-    "commit_date": "2018-11-27 16:57:38",
-    "files_changed": [
-      "manifests/moco-nodes.pp",
-      "modules/signing_scriptworker/manifests/settings.pp",
-      "modules/signing_scriptworker/templates/dep-passwords-mobile.json.erb",
-      "modules/signing_scriptworker/templates/passwords-mobile.json.erb"
     ]
   }
 }

--- a/git_files/build-puppet.md
+++ b/git_files/build-puppet.md
@@ -1,40 +1,34 @@
-## BUILD-PUPPET COMMIT MARKDOWN TABLE SINCE 2018-11-26 21:45:13.184847
+## BUILD-PUPPET COMMIT MARKDOWN TABLE SINCE 2018-11-28 03:50:58.773984
 
 | Commit Number | Commiter | Commit Message | Commit Url | Date | 
 |:---:|:----:|:----------------------------------:|:------:|:----:| 
-|34|dragoscrisan|Force reboot linux workers (#305)    Force reboot linux workers      Force reboot linux workers      Force reboot linux workers      Force reboot linux workers      Create a separate reboot command for OSX and Linux workers      Create a separate reboot command for OSX and Linux workers      Create a separate reboot command for OSX and Linux workers|[URL](https://github.com/mozilla-releng/build-puppet/commit/9f3cf327c3a20d1954ee2627a15b2e8dfa86ea8d)|2018-12-03 08:28:30
-|33|rail|Bug 1511145: don't handle Firefox in releaserunner3 (#316)  Using fake values in case we don't hablde empty arrays properly|[URL](https://github.com/mozilla-releng/build-puppet/commit/6d735b7ae012510bd96641ae01587eefa19fa744)|2018-11-30 17:10:54
-|32|JohanLorenzo|Bump scriptworker to 17.0.1 (#315)|[URL](https://github.com/mozilla-releng/build-puppet/commit/0b8d96d712cfc710e2ca3d08ecaa5682369be068)|2018-11-29 17:12:10
-|31|mitchhentges|Merge pull request #312 from mitchhentges/pushapk-mobile-dep-settings  Adds mobile-dep pushapk env config|[URL](https://github.com/mozilla-releng/build-puppet/commit/de413d0e22b0f5d478efc9dc1ef5dc3233f1eec3)|2018-11-28 23:14:51
-|30|mitchhentges|Adds note that taskcluster_client_id should be simplified|[URL](https://github.com/mozilla-releng/build-puppet/commit/3f41e7d42861eab53e8533a9ade6cfce509e12d8)|2018-11-28 21:17:31
-|29|bccrisan|Merge pull request #314 from mozilla-releng/pyup-scheduled-update-2018-11-28  Scheduled weekly dependency update for week 47|[URL](https://github.com/mozilla-releng/build-puppet/commit/371a7a9d04b4a551a94ec697ccd14cdb995e5956)|2018-11-28 15:44:40
-|28|pyup-bot|Update datadog from 0.24.0 to 0.25.0|[URL](https://github.com/mozilla-releng/build-puppet/commit/d806fa8eb6d2f1005627a7e99e514d83e6190f7e)|2018-11-28 13:05:46
-|27|pyup-bot|Update shipitapi from 1.0.0 to 2.0.0|[URL](https://github.com/mozilla-releng/build-puppet/commit/21e61c2357a202d64e04267ba6925991d7117165)|2018-11-28 13:05:44
-|26|pyup-bot|Update pastescript from 2.0.2 to 3.0.0|[URL](https://github.com/mozilla-releng/build-puppet/commit/13ffca3b9a1601d489ed41e34e1f3c60a4448461)|2018-11-28 13:05:43
-|25|pyup-bot|Update colorama from 0.4.0 to 0.4.1|[URL](https://github.com/mozilla-releng/build-puppet/commit/2da921e5d062a30912d844a3632aa218835efaf5)|2018-11-28 13:05:41
-|24|pyup-bot|Update pygments from 2.2.0 to 2.3.0|[URL](https://github.com/mozilla-releng/build-puppet/commit/a711388f29dee43634cf0e41a5a014a64a897df4)|2018-11-28 13:05:40
-|23|pyup-bot|Update pygments from 2.2.0 to 2.3.0|[URL](https://github.com/mozilla-releng/build-puppet/commit/80004ca00a958184e565a175ead2523ad6b08fd9)|2018-11-28 13:05:38
-|22|pyup-bot|Update botocore from 1.12.49 to 1.12.53|[URL](https://github.com/mozilla-releng/build-puppet/commit/b691dbb0c93a919dde6e6d6dff0a4190bbee6011)|2018-11-28 13:05:37
-|21|pyup-bot|Update boto3 from 1.9.49 to 1.9.53|[URL](https://github.com/mozilla-releng/build-puppet/commit/333c2db10a08e34a2c74280d1854082acf0a844d)|2018-11-28 13:05:35
-|20|pyup-bot|Update redo from 2.0.1 to 2.0.2|[URL](https://github.com/mozilla-releng/build-puppet/commit/410887dbca21edbdbf364250b89c6120f2234d8f)|2018-11-28 13:05:34
-|19|pyup-bot|Update redo from 2.0.1 to 2.0.2|[URL](https://github.com/mozilla-releng/build-puppet/commit/cec6017333c9150ae45328ef5684d56bf60280b7)|2018-11-28 13:05:32
-|18|pyup-bot|Update redo from 2.0.1 to 2.0.2|[URL](https://github.com/mozilla-releng/build-puppet/commit/973f0a627c2ee4127735f7675ddbd8e4ea2ea641)|2018-11-28 13:05:31
-|17|pyup-bot|Update redo from 2.0.1 to 2.0.2|[URL](https://github.com/mozilla-releng/build-puppet/commit/d67175b59a04b99c46791288c200f3b8d1fbfe5c)|2018-11-28 13:05:29
-|16|pyup-bot|Update multidict from 4.5.0 to 4.5.1|[URL](https://github.com/mozilla-releng/build-puppet/commit/c3a22a569600f6fcb842a287c84e1860c759aee7)|2018-11-28 13:05:28
-|15|pyup-bot|Update multidict from 4.5.0 to 4.5.1|[URL](https://github.com/mozilla-releng/build-puppet/commit/f0ae756d4a54371e3e082929d028465e8e593784)|2018-11-28 13:05:26
-|14|pyup-bot|Update multidict from 4.5.0 to 4.5.1|[URL](https://github.com/mozilla-releng/build-puppet/commit/1579d8ae5b16aa152bf3a5e9a3666279d8fee9ab)|2018-11-28 13:05:25
-|13|pyup-bot|Update multidict from 4.5.0 to 4.5.1|[URL](https://github.com/mozilla-releng/build-puppet/commit/ed260321124368673f248ce7bc7a467cb151347f)|2018-11-28 13:05:23
-|12|pyup-bot|Update multidict from 4.5.0 to 4.5.1|[URL](https://github.com/mozilla-releng/build-puppet/commit/31e85a85cd1ea5f27985afd9f5c76d490418149c)|2018-11-28 13:05:22
-|11|pyup-bot|Update multidict from 4.5.0 to 4.5.1|[URL](https://github.com/mozilla-releng/build-puppet/commit/d23aec5b060ccc9b60befaae38703fa51d6840a2)|2018-11-28 13:05:20
-|10|pyup-bot|Update multidict from 4.5.0 to 4.5.1|[URL](https://github.com/mozilla-releng/build-puppet/commit/7a0c861a443e381b14834aad9b1035958c451437)|2018-11-28 13:05:19
-|9|pyup-bot|Update multidict from 4.5.0 to 4.5.1|[URL](https://github.com/mozilla-releng/build-puppet/commit/583b80727f88ab3e2a12cfab84ea59a6d19f18c5)|2018-11-28 13:05:17
-|8|pyup-bot|Update multidict from 4.5.0 to 4.5.1|[URL](https://github.com/mozilla-releng/build-puppet/commit/84ae0b2b76a0a47ff237b91f9e6fc142297c4868)|2018-11-28 13:05:15
-|7|MihaiTabara|Merge pull request #313 from MihaiTabara/bump  Bump beetmoverscript in beetmoverworkers.|[URL](https://github.com/mozilla-releng/build-puppet/commit/49597d5fde15e95384b4fc34b91f8f7c0a2502e5)|2018-11-28 09:53:35
-|6|MihaiTabara|Bump beetmoverscript in beetmoverworkers.|[URL](https://github.com/mozilla-releng/build-puppet/commit/2aef9521b2bfabde8cbbd2e8388dab84b017f5ca)|2018-11-28 01:11:53
-|5|mitchhentges|Adds mobile-dep pushapk env config|[URL](https://github.com/mozilla-releng/build-puppet/commit/4d55efd50ee5b9ca6f6d1e2c76bd11ed503918c7)|2018-11-28 00:04:27
-|4|tomprince|Merge pull request #311 from tp-tc/scriptworker-cron  Bump scriptworker to 17.0.0 for push information in cron tasks.|[URL](https://github.com/mozilla-releng/build-puppet/commit/bfeb4b9b7a7931e277c607283e99f9c5c323fb28)|2018-11-27 21:24:14
-|3|tomprince|Bump scriptworker to 17.0.0 for push information in cron tasks.|[URL](https://github.com/mozilla-releng/build-puppet/commit/08f05d12e2cae01c387e5ac0b19c3d78597828d2)|2018-11-27 18:00:24
-|2|tomprince|Merge pull request #309 from tp-tc/whats-new  Update balrogscript for WNP support.|[URL](https://github.com/mozilla-releng/build-puppet/commit/81815340e943aab9e886a3f6c799d58c101451ac)|2018-11-27 17:02:34
-|1|mitchhentges|Merge pull request #303 from mitchhentges/bug1508508  Adds configuration for reference browser (prod and staging)|[URL](https://github.com/mozilla-releng/build-puppet/commit/a198270e36c42b6541542d48f895c8479415b9b7)|2018-11-27 16:57:38
+|28|dragoscrisan|Force reboot linux workers (#305)    Force reboot linux workers      Force reboot linux workers      Force reboot linux workers      Force reboot linux workers      Create a separate reboot command for OSX and Linux workers      Create a separate reboot command for OSX and Linux workers      Create a separate reboot command for OSX and Linux workers|[URL](https://github.com/mozilla-releng/build-puppet/commit/9f3cf327c3a20d1954ee2627a15b2e8dfa86ea8d)|2018-12-03 08:28:30
+|27|rail|Bug 1511145: don't handle Firefox in releaserunner3 (#316)  Using fake values in case we don't hablde empty arrays properly|[URL](https://github.com/mozilla-releng/build-puppet/commit/6d735b7ae012510bd96641ae01587eefa19fa744)|2018-11-30 17:10:54
+|26|JohanLorenzo|Bump scriptworker to 17.0.1 (#315)|[URL](https://github.com/mozilla-releng/build-puppet/commit/0b8d96d712cfc710e2ca3d08ecaa5682369be068)|2018-11-29 17:12:10
+|25|mitchhentges|Merge pull request #312 from mitchhentges/pushapk-mobile-dep-settings  Adds mobile-dep pushapk env config|[URL](https://github.com/mozilla-releng/build-puppet/commit/de413d0e22b0f5d478efc9dc1ef5dc3233f1eec3)|2018-11-28 23:14:51
+|24|mitchhentges|Adds note that taskcluster_client_id should be simplified|[URL](https://github.com/mozilla-releng/build-puppet/commit/3f41e7d42861eab53e8533a9ade6cfce509e12d8)|2018-11-28 21:17:31
+|23|bccrisan|Merge pull request #314 from mozilla-releng/pyup-scheduled-update-2018-11-28  Scheduled weekly dependency update for week 47|[URL](https://github.com/mozilla-releng/build-puppet/commit/371a7a9d04b4a551a94ec697ccd14cdb995e5956)|2018-11-28 15:44:40
+|22|pyup-bot|Update datadog from 0.24.0 to 0.25.0|[URL](https://github.com/mozilla-releng/build-puppet/commit/d806fa8eb6d2f1005627a7e99e514d83e6190f7e)|2018-11-28 13:05:46
+|21|pyup-bot|Update shipitapi from 1.0.0 to 2.0.0|[URL](https://github.com/mozilla-releng/build-puppet/commit/21e61c2357a202d64e04267ba6925991d7117165)|2018-11-28 13:05:44
+|20|pyup-bot|Update pastescript from 2.0.2 to 3.0.0|[URL](https://github.com/mozilla-releng/build-puppet/commit/13ffca3b9a1601d489ed41e34e1f3c60a4448461)|2018-11-28 13:05:43
+|19|pyup-bot|Update colorama from 0.4.0 to 0.4.1|[URL](https://github.com/mozilla-releng/build-puppet/commit/2da921e5d062a30912d844a3632aa218835efaf5)|2018-11-28 13:05:41
+|18|pyup-bot|Update pygments from 2.2.0 to 2.3.0|[URL](https://github.com/mozilla-releng/build-puppet/commit/a711388f29dee43634cf0e41a5a014a64a897df4)|2018-11-28 13:05:40
+|17|pyup-bot|Update pygments from 2.2.0 to 2.3.0|[URL](https://github.com/mozilla-releng/build-puppet/commit/80004ca00a958184e565a175ead2523ad6b08fd9)|2018-11-28 13:05:38
+|16|pyup-bot|Update botocore from 1.12.49 to 1.12.53|[URL](https://github.com/mozilla-releng/build-puppet/commit/b691dbb0c93a919dde6e6d6dff0a4190bbee6011)|2018-11-28 13:05:37
+|15|pyup-bot|Update boto3 from 1.9.49 to 1.9.53|[URL](https://github.com/mozilla-releng/build-puppet/commit/333c2db10a08e34a2c74280d1854082acf0a844d)|2018-11-28 13:05:35
+|14|pyup-bot|Update redo from 2.0.1 to 2.0.2|[URL](https://github.com/mozilla-releng/build-puppet/commit/410887dbca21edbdbf364250b89c6120f2234d8f)|2018-11-28 13:05:34
+|13|pyup-bot|Update redo from 2.0.1 to 2.0.2|[URL](https://github.com/mozilla-releng/build-puppet/commit/cec6017333c9150ae45328ef5684d56bf60280b7)|2018-11-28 13:05:32
+|12|pyup-bot|Update redo from 2.0.1 to 2.0.2|[URL](https://github.com/mozilla-releng/build-puppet/commit/973f0a627c2ee4127735f7675ddbd8e4ea2ea641)|2018-11-28 13:05:31
+|11|pyup-bot|Update redo from 2.0.1 to 2.0.2|[URL](https://github.com/mozilla-releng/build-puppet/commit/d67175b59a04b99c46791288c200f3b8d1fbfe5c)|2018-11-28 13:05:29
+|10|pyup-bot|Update multidict from 4.5.0 to 4.5.1|[URL](https://github.com/mozilla-releng/build-puppet/commit/c3a22a569600f6fcb842a287c84e1860c759aee7)|2018-11-28 13:05:28
+|9|pyup-bot|Update multidict from 4.5.0 to 4.5.1|[URL](https://github.com/mozilla-releng/build-puppet/commit/f0ae756d4a54371e3e082929d028465e8e593784)|2018-11-28 13:05:26
+|8|pyup-bot|Update multidict from 4.5.0 to 4.5.1|[URL](https://github.com/mozilla-releng/build-puppet/commit/1579d8ae5b16aa152bf3a5e9a3666279d8fee9ab)|2018-11-28 13:05:25
+|7|pyup-bot|Update multidict from 4.5.0 to 4.5.1|[URL](https://github.com/mozilla-releng/build-puppet/commit/ed260321124368673f248ce7bc7a467cb151347f)|2018-11-28 13:05:23
+|6|pyup-bot|Update multidict from 4.5.0 to 4.5.1|[URL](https://github.com/mozilla-releng/build-puppet/commit/31e85a85cd1ea5f27985afd9f5c76d490418149c)|2018-11-28 13:05:22
+|5|pyup-bot|Update multidict from 4.5.0 to 4.5.1|[URL](https://github.com/mozilla-releng/build-puppet/commit/d23aec5b060ccc9b60befaae38703fa51d6840a2)|2018-11-28 13:05:20
+|4|pyup-bot|Update multidict from 4.5.0 to 4.5.1|[URL](https://github.com/mozilla-releng/build-puppet/commit/7a0c861a443e381b14834aad9b1035958c451437)|2018-11-28 13:05:19
+|3|pyup-bot|Update multidict from 4.5.0 to 4.5.1|[URL](https://github.com/mozilla-releng/build-puppet/commit/583b80727f88ab3e2a12cfab84ea59a6d19f18c5)|2018-11-28 13:05:17
+|2|pyup-bot|Update multidict from 4.5.0 to 4.5.1|[URL](https://github.com/mozilla-releng/build-puppet/commit/84ae0b2b76a0a47ff237b91f9e6fc142297c4868)|2018-11-28 13:05:15
+|1|MihaiTabara|Merge pull request #313 from MihaiTabara/bump  Bump beetmoverscript in beetmoverworkers.|[URL](https://github.com/mozilla-releng/build-puppet/commit/49597d5fde15e95384b4fc34b91f8f7c0a2502e5)|2018-11-28 09:53:35
 
 

--- a/git_files/mozapkpublisher.json
+++ b/git_files/mozapkpublisher.json
@@ -1,6 +1,6 @@
 {
   "0": {
-    "lastChecked": "2018-12-03 19:45:59.597523",
+    "lastChecked": "2018-12-05 01:51:34.726198",
     "last_two_releases": {
       "LatestRelease": {
         "version": "0.9.2",

--- a/git_files/mozapkpublisher.md
+++ b/git_files/mozapkpublisher.md
@@ -1,4 +1,5 @@
-## MOZAPKPUBLISHER COMMIT MARKDOWN TABLE SINCE 2018-11-26 21:45:13.184847
+## REPOSITORY NAME: MOZAPKPUBLISHER
+ CURRENT VERSION: 0.9.2 RELEASED ON THU, 08 NOV 2018 09:57:02 GMT
 
 | Commit Number | Commiter | Commit Message | Commit Url | Date | 
 |:---:|:----:|:----------------------------------:|:------:|:----:| 

--- a/git_files/pushapkscript.md
+++ b/git_files/pushapkscript.md
@@ -1,4 +1,5 @@
-## PUSHAPKSCRIPT COMMIT MARKDOWN TABLE SINCE 2018-11-26 21:45:13.184847
+## REPOSITORY NAME: PUSHAPKSCRIPT
+ CURRENT VERSION: 0.9.0 RELEASED ON FRI, 23 NOV 2018 15:41:35 GMT
 
 | Commit Number | Commiter | Commit Message | Commit Url | Date | 
 |:---:|:----:|:----------------------------------:|:------:|:----:| 

--- a/git_files/pushsnapscript.md
+++ b/git_files/pushsnapscript.md
@@ -1,4 +1,5 @@
-## PUSHSNAPSCRIPT COMMIT MARKDOWN TABLE SINCE 2018-11-26 21:45:13.184847
+## REPOSITORY NAME: PUSHSNAPSCRIPT
+ CURRENT VERSION: 0.2.4 RELEASED ON MON, 08 OCT 2018 09:00:24 GMT
 
 | Commit Number | Commiter | Commit Message | Commit Url | Date | 
 |:---:|:----:|:----------------------------------:|:------:|:----:| 

--- a/git_files/scriptworker.json
+++ b/git_files/scriptworker.json
@@ -1,6 +1,6 @@
 {
   "0": {
-    "lastChecked": "2018-12-03 19:46:08.747191",
+    "lastChecked": "2018-12-05 01:51:39.361822",
     "last_two_releases": {
       "LatestRelease": {
         "version": "17.0.0",

--- a/git_files/scriptworker.md
+++ b/git_files/scriptworker.md
@@ -1,4 +1,5 @@
-## SCRIPTWORKER COMMIT MARKDOWN TABLE SINCE 2018-11-26 21:45:13.184847
+## REPOSITORY NAME: SCRIPTWORKER
+ CURRENT VERSION: 17.0.0 RELEASED ON TUE, 27 NOV 2018 17:46:52 GMT
 
 | Commit Number | Commiter | Commit Message | Commit Url | Date | 
 |:---:|:----:|:----------------------------------:|:------:|:----:| 
@@ -7,7 +8,7 @@
 |11|escapewindow|update pinned requirements|[URL](https://github.com/mozilla-releng/scriptworker/commit/48f9c9ca3c0d1eaae3c41d76f9166224a6eee45f)|2018-11-13 21:10:04
 |10|escapewindow|address review comments|[URL](https://github.com/mozilla-releng/scriptworker/commit/f760315f4f9f06e9492f4c87d8b79cfa0bde61c6)|2018-11-13 21:09:55
 |9|escapewindow|pin hashes via pip-compile-multi in docker  I've been pinning mac-specific wheel hashes in dephash, which is wrong.|[URL](https://github.com/mozilla-releng/scriptworker/commit/648de55b994a2fb9f57bd6991e7a8a54ef3a4790)|2018-10-30 23:37:30
-|8|MihaiTabara|Merge pull request #270 from MihaiTabara/docs  Bug 1503549 - improve docs for ramping up scriptworkers after aws-manâ€¦|[URL](https://github.com/mozilla-releng/scriptworker/commit/7ecf1958e98b1822e596651a62c1581bde8b7436)|2018-11-02 23:16:33
+|8|MihaiTabara|Merge pull request #270 from MihaiTabara/docs  Bug 1503549 - improve docs for ramping up scriptworkers after aws-man…|[URL](https://github.com/mozilla-releng/scriptworker/commit/7ecf1958e98b1822e596651a62c1581bde8b7436)|2018-11-02 23:16:33
 |7|MihaiTabara|Fix markdown syntax.|[URL](https://github.com/mozilla-releng/scriptworker/commit/b722dc37d9187e791e13dd4c190880f74034250d)|2018-11-02 23:03:24
 |6|MihaiTabara|Fix flake8 issues.|[URL](https://github.com/mozilla-releng/scriptworker/commit/c63ffda1e5131ea82c157f117f01098e53b9ebf4)|2018-11-02 22:05:21
 |5|MihaiTabara|Bug 1503549 - improve docs for ramping up scriptworkers after aws-manager2 retirement.|[URL](https://github.com/mozilla-releng/scriptworker/commit/34f792dc72185b3ea99c1c81a7d3337674779b84)|2018-11-02 21:52:28

--- a/git_files/services.json
+++ b/git_files/services.json
@@ -1,6 +1,6 @@
 {
   "0": {
-    "lastChecked": "2018-12-03 19:45:16.961051",
+    "lastChecked": "2018-12-05 01:51:02.545423",
     "last_two_releases": {
       "LatestRelease": {
         "version": "v51",

--- a/git_files/services.md
+++ b/git_files/services.md
@@ -1,4 +1,5 @@
-## SERVICES COMMIT MARKDOWN TABLE SINCE 2018-11-26 21:45:13.184847
+## REPOSITORY NAME: SERVICES
+ CURRENT VERSION: V51 RELEASED ON WED, 21 NOV 2018 18:05:34 GMT
 
 | Commit Number | Commiter | Commit Message | Commit Url | Date | 
 |:---:|:----:|:----------------------------------:|:------:|:----:| 

--- a/git_files/ship-it.json
+++ b/git_files/ship-it.json
@@ -1,6 +1,6 @@
 {
   "0": {
-    "lastChecked": "2018-12-03 19:45:14.208158",
+    "lastChecked": "2018-12-05 01:50:59.681515",
     "last_two_releases": null
   },
   "1": {

--- a/git_files/ship-it.md
+++ b/git_files/ship-it.md
@@ -1,4 +1,4 @@
-## SHIP-IT COMMIT MARKDOWN TABLE SINCE 2018-11-26 21:45:13.184847
+## SHIP-IT COMMIT MARKDOWN TABLE SINCE 2018-11-28 03:50:58.773984
 
 | Commit Number | Commiter | Commit Message | Commit Url | Date | 
 |:---:|:----:|:----------------------------------:|:------:|:----:| 

--- a/git_files/shipitscript.json
+++ b/git_files/shipitscript.json
@@ -1,6 +1,6 @@
 {
   "0": {
-    "lastChecked": "2018-12-03 19:45:49.712887",
+    "lastChecked": "2018-12-05 01:51:27.471385",
     "last_two_releases": {
       "LatestRelease": {
         "version": "3.0.0",

--- a/git_files/shipitscript.md
+++ b/git_files/shipitscript.md
@@ -1,4 +1,5 @@
-## SHIPITSCRIPT COMMIT MARKDOWN TABLE SINCE 2018-11-26 21:45:13.184847
+## REPOSITORY NAME: SHIPITSCRIPT
+ CURRENT VERSION: 3.0.0 RELEASED ON WED, 21 NOV 2018 16:33:53 GMT
 
 | Commit Number | Commiter | Commit Message | Commit Url | Date | 
 |:---:|:----:|:----------------------------------:|:------:|:----:| 

--- a/git_files/signingscript.md
+++ b/git_files/signingscript.md
@@ -1,4 +1,5 @@
-## SIGNINGSCRIPT COMMIT MARKDOWN TABLE SINCE 2018-11-26 21:45:13.184847
+## REPOSITORY NAME: SIGNINGSCRIPT
+ CURRENT VERSION: 9.5.1 RELEASED ON FRI, 23 NOV 2018 13:14:04 GMT
 
 | Commit Number | Commiter | Commit Message | Commit Url | Date | 
 |:---:|:----:|:----------------------------------:|:------:|:----:| 

--- a/git_files/signtool.json
+++ b/git_files/signtool.json
@@ -1,6 +1,6 @@
 {
   "0": {
-    "lastChecked": "2018-12-03 19:46:21.174449",
+    "lastChecked": "2018-12-05 01:51:49.804993",
     "last_two_releases": {
       "LatestRelease": {
         "version": "3.2.1",

--- a/git_files/signtool.md
+++ b/git_files/signtool.md
@@ -1,4 +1,5 @@
-## SIGNTOOL COMMIT MARKDOWN TABLE SINCE 2018-11-26 21:45:13.184847
+## REPOSITORY NAME: SIGNTOOL
+ CURRENT VERSION: 3.2.1 RELEASED ON MON, 27 AUG 2018 17:17:03 GMT
 
 | Commit Number | Commiter | Commit Message | Commit Url | Date | 
 |:---:|:----:|:----------------------------------:|:------:|:----:| 

--- a/git_files/taskcluster-auth.json
+++ b/git_files/taskcluster-auth.json
@@ -1,6 +1,6 @@
 {
   "0": {
-    "lastChecked": "2018-12-03 19:46:26.044108",
+    "lastChecked": "2018-12-05 01:51:54.337880",
     "last_two_releases": null
   },
   "1": {
@@ -45,19 +45,6 @@
     "commit_date": "2018-11-28 22:01:44",
     "files_changed": [
       "src/v1.js"
-    ]
-  },
-  "5": {
-    "sha": "68bd2858a24e54fb079e76b8997b1ef19bfb5f88",
-    "url": "https://github.com/taskcluster/taskcluster-auth/commit/68bd2858a24e54fb079e76b8997b1ef19bfb5f88",
-    "commiter_name": "djmitche",
-    "commiter_email": null,
-    "commit_message": "Merge pull request #184 from djmitche/bug1456909  Bug 1456909 - use monitor.oneShot",
-    "commit_date": "2018-11-26 22:08:53",
-    "files_changed": [
-      "package.json",
-      "src/main.js",
-      "yarn.lock"
     ]
   }
 }

--- a/git_files/taskcluster-auth.md
+++ b/git_files/taskcluster-auth.md
@@ -1,11 +1,10 @@
-## TASKCLUSTER-AUTH COMMIT MARKDOWN TABLE SINCE 2018-11-26 21:45:13.184847
+## TASKCLUSTER-AUTH COMMIT MARKDOWN TABLE SINCE 2018-11-28 03:50:58.773984
 
 | Commit Number | Commiter | Commit Message | Commit Url | Date | 
 |:---:|:----:|:----------------------------------:|:------:|:----:| 
-|5|djmitche|Merge pull request #185 from djmitche/bug1509089  Bug 1509089 - remove LOCK_ROLES support|[URL](https://github.com/taskcluster/taskcluster-auth/commit/dbbcef916c53765e535d7cd9580367089cec3a17)|2018-11-30 02:24:43
-|4|djmitche|Merge pull request #186 from djmitche/bug1509154  Bug 1509154 - await row removals|[URL](https://github.com/taskcluster/taskcluster-auth/commit/9babc5e6d48fc27013e58e8e67eb085bfaa6561e)|2018-11-30 02:24:34
-|3|djmitche|Bug 1509154 - await row removals|[URL](https://github.com/taskcluster/taskcluster-auth/commit/6375db436a015e587979ded3e94fe36cd90ec7c6)|2018-11-29 01:23:01
-|2|djmitche|Bug 1509089 - remove LOCK_ROLES support  This was a big old hack meant to block changes to roles during the transition to storing roles in a blob.  It's not needed anymore.|[URL](https://github.com/taskcluster/taskcluster-auth/commit/b8c3dfe5dc51e448e3c4773b7bd386e8db37ffe9)|2018-11-28 22:01:44
-|1|djmitche|Merge pull request #184 from djmitche/bug1456909  Bug 1456909 - use monitor.oneShot|[URL](https://github.com/taskcluster/taskcluster-auth/commit/68bd2858a24e54fb079e76b8997b1ef19bfb5f88)|2018-11-26 22:08:53
+|4|djmitche|Merge pull request #185 from djmitche/bug1509089  Bug 1509089 - remove LOCK_ROLES support|[URL](https://github.com/taskcluster/taskcluster-auth/commit/dbbcef916c53765e535d7cd9580367089cec3a17)|2018-11-30 02:24:43
+|3|djmitche|Merge pull request #186 from djmitche/bug1509154  Bug 1509154 - await row removals|[URL](https://github.com/taskcluster/taskcluster-auth/commit/9babc5e6d48fc27013e58e8e67eb085bfaa6561e)|2018-11-30 02:24:34
+|2|djmitche|Bug 1509154 - await row removals|[URL](https://github.com/taskcluster/taskcluster-auth/commit/6375db436a015e587979ded3e94fe36cd90ec7c6)|2018-11-29 01:23:01
+|1|djmitche|Bug 1509089 - remove LOCK_ROLES support  This was a big old hack meant to block changes to roles during the transition to storing roles in a blob.  It's not needed anymore.|[URL](https://github.com/taskcluster/taskcluster-auth/commit/b8c3dfe5dc51e448e3c4773b7bd386e8db37ffe9)|2018-11-28 22:01:44
 
 

--- a/git_files/taskcluster-queue.json
+++ b/git_files/taskcluster-queue.json
@@ -1,6 +1,6 @@
 {
   "0": {
-    "lastChecked": "2018-12-03 19:46:28.878445",
+    "lastChecked": "2018-12-05 01:51:56.596825",
     "last_two_releases": null
   },
   "1": {
@@ -23,31 +23,6 @@
     "commit_date": "2018-11-29 01:12:10",
     "files_changed": [
       "test/helper.js"
-    ]
-  },
-  "3": {
-    "sha": "eae5a8ff58e6edaac15fd95d273509c8045da3f6",
-    "url": "https://github.com/taskcluster/taskcluster-queue/commit/eae5a8ff58e6edaac15fd95d273509c8045da3f6",
-    "commiter_name": "djmitche",
-    "commiter_email": null,
-    "commit_message": "Bug 1509186 - remove references to taskcluster.net from the API description",
-    "commit_date": "2018-11-26 18:08:58",
-    "files_changed": [
-      "src/api.js",
-      "src/exchanges.js"
-    ]
-  },
-  "4": {
-    "sha": "9595f61cd17ad72c315e52d7d950026527ded5c6",
-    "url": "https://github.com/taskcluster/taskcluster-queue/commit/9595f61cd17ad72c315e52d7d950026527ded5c6",
-    "commiter_name": "djmitche",
-    "commiter_email": null,
-    "commit_message": "Merge pull request #303 from djmitche/bug1456909  Bug 1456909 - use monitor.oneShot()",
-    "commit_date": "2018-11-26 22:05:11",
-    "files_changed": [
-      "package.json",
-      "src/main.js",
-      "yarn.lock"
     ]
   }
 }

--- a/git_files/taskcluster-queue.md
+++ b/git_files/taskcluster-queue.md
@@ -1,10 +1,8 @@
-## TASKCLUSTER-QUEUE COMMIT MARKDOWN TABLE SINCE 2018-11-26 21:45:13.184847
+## TASKCLUSTER-QUEUE COMMIT MARKDOWN TABLE SINCE 2018-11-28 03:50:58.773984
 
 | Commit Number | Commiter | Commit Message | Commit Url | Date | 
 |:---:|:----:|:----------------------------------:|:------:|:----:| 
-|4|djmitche|Merge pull request #304 from djmitche/bug1509189  Bug 1509189 - use unique table names to avoid conflicts|[URL](https://github.com/taskcluster/taskcluster-queue/commit/c3a424aa0811c0b8bef42219a485d5a179a14ba2)|2018-11-30 02:12:03
-|3|djmitche|Bug 1509189 - use unique table names to avoid conflicts  Taskcluster-Github already does something like this.  The tables get cleaned out and should have no rows at test completion, so this doesn't use a lot of space.  There's no limit (aside from space) on the number of tables in an account.|[URL](https://github.com/taskcluster/taskcluster-queue/commit/cb8f3946830b982b58d2f93b99202cab15f40719)|2018-11-29 01:12:10
-|2|djmitche|Bug 1509186 - remove references to taskcluster.net from the API description|[URL](https://github.com/taskcluster/taskcluster-queue/commit/eae5a8ff58e6edaac15fd95d273509c8045da3f6)|2018-11-26 18:08:58
-|1|djmitche|Merge pull request #303 from djmitche/bug1456909  Bug 1456909 - use monitor.oneShot()|[URL](https://github.com/taskcluster/taskcluster-queue/commit/9595f61cd17ad72c315e52d7d950026527ded5c6)|2018-11-26 22:05:11
+|2|djmitche|Merge pull request #304 from djmitche/bug1509189  Bug 1509189 - use unique table names to avoid conflicts|[URL](https://github.com/taskcluster/taskcluster-queue/commit/c3a424aa0811c0b8bef42219a485d5a179a14ba2)|2018-11-30 02:12:03
+|1|djmitche|Bug 1509189 - use unique table names to avoid conflicts  Taskcluster-Github already does something like this.  The tables get cleaned out and should have no rows at test completion, so this doesn't use a lot of space.  There's no limit (aside from space) on the number of tables in an account.|[URL](https://github.com/taskcluster/taskcluster-queue/commit/cb8f3946830b982b58d2f93b99202cab15f40719)|2018-11-29 01:12:10
 
 

--- a/git_files/treescript.md
+++ b/git_files/treescript.md
@@ -1,4 +1,5 @@
-## TREESCRIPT COMMIT MARKDOWN TABLE SINCE 2018-11-26 21:45:13.184847
+## REPOSITORY NAME: TREESCRIPT
+ CURRENT VERSION: 1.1.3 RELEASED ON WED, 31 OCT 2018 21:21:07 GMT
 
 | Commit Number | Commiter | Commit Message | Commit Url | Date | 
 |:---:|:----:|:----------------------------------:|:------:|:----:| 

--- a/main_md_table.md
+++ b/main_md_table.md
@@ -1,125 +1,26 @@
 #  Last five commits from every repository 
 
-|	try	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/try.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/try.json)	| 
+|	autoland	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/autoland.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/autoland.json)	| 
 |:----------------:|:-------------------------------------:|:---------------------------------:| 
  
 |      Repository      |                   Last commit               |    Deploy time       | 
 |:--------------------:|:-------------------------------------------:|:--------------------:| 
-|[Link to commit](https://hg.mozilla.org/try/pushloghtml?changeset=681e43225721)|try: -b do -p win32,win64,linux64,linux -u web-platform-tests-e10s-1[linux64-stylo,Ubuntu,10.10,Windows 10],web-platform-tests-1[linux64-stylo,Ubuntu,10.10,Windows 10] -t none --artifact --try-test-paths web-platform-tests:testing/web-platform/tests/web-animations/animation-model/animation-types/accumulation-per-property.html web-platform-tests:testing/web-platform/tests/web-animations/animation-model/animation-types/addition-per-property.html web-platform-tests:testing/web-platform/tests/web-animations/animation-model/animation-types/interpolation-per-property.html|2018-12-03 19:36:25|
-|[Link to commit](https://hg.mozilla.org/try/pushloghtml?changeset=ebaa8ea0b039)|Bug 1509898 [wpt PR 14236] - Simplify interpolation of 2-D matrix transforms., a=testonly  The decomposition of a transformation matrix into translations, rotation, scale and skew transforms is not unique. In some cases, the generalized 3-D decomposition does not align with the working draft for CSS transforms (https://drafts.csswg.org/css-transforms/).  In the special case where the transforms being interpolated are both 2-D, a simplified model provides more restricted set of decomposition transforms with less computational overhead.  Bug: 797472 Change-Id: I2b8ba99fe02c2eef878d94f5dfaea55c39652759 Reviewed-on: https://chromium-review.googlesource.com/c/1332253 Commit-Queue: Kevin Ellis <kevers@chromium.org> Commit-Queue: Ian Vollick <vollick@chromium.org> Reviewed-by: Ian Vollick <vollick@chromium.org> Cr-Commit-Position: refs/heads/master@{#613191}  wpt-commit: a8ce772c68778cfb2c273fffb81e61da62d77bef wpt-pr: 14236 |2018-12-03 19:31:48|
-|[Link to commit](https://hg.mozilla.org/try/pushloghtml?changeset=ad2c0b8a5d45)|try: -b do -p win32,win64,linux64,linux -u web-platform-tests-e10s-1[linux64-stylo,Ubuntu,10.10,Windows 10],web-platform-tests-1[linux64-stylo,Ubuntu,10.10,Windows 10] -t none --artifact --rebuild 10 --try-test-paths web-platform-tests:testing/web-platform/tests/web-animations/animation-model/animation-types/accumulation-per-property.html web-platform-tests:testing/web-platform/tests/web-animations/animation-model/animation-types/addition-per-property.html web-platform-tests:testing/web-platform/tests/web-animations/animation-model/animation-types/interpolation-per-property.html|2018-12-03 19:08:16|
-|[Link to commit](https://hg.mozilla.org/try/pushloghtml?changeset=ed96a106a834)|try: -b do -p win32,win64,linux64,linux -u web-platform-tests-e10s-1[linux64-stylo,Ubuntu,10.10,Windows 10],web-platform-tests-1[linux64-stylo,Ubuntu,10.10,Windows 10] -t none --artifact --rebuild 10 --try-test-paths web-platform-tests:testing/web-platform/tests/webrtc/RTCRtpSender-transport.https.html|2018-12-03 19:01:24|
-|[Link to commit](https://hg.mozilla.org/try/pushloghtml?changeset=d78db7bc9f93)|Bug 1511855 [wpt PR 14341] - Update wpt metadata, a=testonly  wpt-pr: 14341 wpt-type: metadata |2018-12-03 19:01:07|
-
-|	ci-configuration	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/ci-configuration.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/ci-configuration.json)	| 
-|:----------------:|:-------------------------------------:|:---------------------------------:| 
- 
-|      Repository      |                   Last commit               |    Deploy time       | 
-|:--------------------:|:-------------------------------------------:|:--------------------:| 
-|[Link to commit](https://hg.mozilla.org/build/ci-configuration/pushloghtml?changeset=e9634d8942ca)|Bug 1510441: Use sparse profile in cron tasks; r=gps  Differential Revision: https://phabricator.services.mozilla.com/D13141|2018-11-30 13:01:34|
-|[Link to commit](https://hg.mozilla.org/build/ci-configuration/pushloghtml?changeset=13cbc18135d2)|Bug 1503894 - reenable taskcluster-cron for comm-central repo. r=tomprince  This goes along with a .cron.yml update in comm-central that removes the periodic-file-update cron configuration. (Bug 1499590 comment 15)  This will get comm-central nightly builds working again.  Differential Revision: https://phabricator.services.mozilla.com/D10959|2018-11-06 21:44:29|
-|[Link to commit](https://hg.mozilla.org/build/ci-configuration/pushloghtml?changeset=38144ac82b0a)|Bug 1503894 - disable taskcluster-cron for comm-central repos r=tomprince  The cron hook expects that it is checking out a gecko tree.  Robustcheckout kind of loses its mind when it clones mozilla-unified, then finds no ancestor in common with a comm-central pull.  Differential Revision: https://phabricator.services.mozilla.com/D10595|2018-11-01 18:52:02|
-|[Link to commit](https://hg.mozilla.org/build/ci-configuration/pushloghtml?changeset=48d479b3411b)|Bug 1502976 - upgrade decision image to the latest r=tomprince  Differential Revision: https://phabricator.services.mozilla.com/D10124|2018-10-29 21:38:55|
-|[Link to commit](https://hg.mozilla.org/build/ci-configuration/pushloghtml?changeset=d56b6be4c4c1)|Bug 1499590 - Enable taskcluster-cron on additional comm- repos. r=dustin  The periodic-file-updates cron task is meant to run on comm-central, comm-beta, and comm-esr60 like it's mozilla- counterpart task.  Differential Revision: https://phabricator.services.mozilla.com/D9860|2018-10-26 17:55:26|
-
-|	mozilla-build	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/mozilla-build.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/mozilla-build.json)	| 
-|:----------------:|:-------------------------------------:|:---------------------------------:| 
- 
-|      Repository      |                   Last commit               |    Deploy time       | 
-|:--------------------:|:-------------------------------------------:|:--------------------:| 
-|[Link to commit](https://hg.mozilla.org/mozilla-build/pushloghtml?changeset=c5a55cf36958)|Bug 1501406 - Update vswhere to version 2.5.2.|2018-10-23 19:12:46|
-|[Link to commit](https://hg.mozilla.org/mozilla-build/pushloghtml?changeset=400ec3910570)|Bug 1501403 - Update UPX to version 3.95.|2018-10-23 19:08:31|
-|[Link to commit](https://hg.mozilla.org/mozilla-build/pushloghtml?changeset=5b1cf2c85207)|Bug 1501399 - Update emacs to version 26.1.|2018-10-23 18:57:20|
-|[Link to commit](https://hg.mozilla.org/mozilla-build/pushloghtml?changeset=d45e1040d212)|Bug 1501395 - Update the bundled sqlite3 DLL to 3.25.2.|2018-10-23 18:55:33|
-|[Link to commit](https://hg.mozilla.org/mozilla-build/pushloghtml?changeset=1af5fbf9b763)|Bug 1501395 - Update python3 to version 3.7.1.|2018-10-23 18:53:23|
-
-|	ci-admin	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/ci-admin.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/ci-admin.json)	| 
-|:----------------:|:-------------------------------------:|:---------------------------------:| 
- 
-|      Repository      |                   Last commit               |    Deploy time       | 
-|:--------------------:|:-------------------------------------------:|:--------------------:| 
-|[Link to commit](https://hg.mozilla.org/build/ci-admin/pushloghtml?changeset=99d859a7a655)|Bug 1492665 - add modify_resources support r=Callek,bstack  Differential Revision: https://phabricator.services.mozilla.com/D6933|2018-10-22 17:52:14|
-|[Link to commit](https://hg.mozilla.org/build/ci-admin/pushloghtml?changeset=241f75b5d808)|Bug 1492665 - add support for environments.yml r=Callek,bstack  Differential Revision: https://phabricator.services.mozilla.com/D6932|2018-10-22 17:52:13|
-|[Link to commit](https://hg.mozilla.org/build/ci-admin/pushloghtml?changeset=d1796b61fbd0)|Bug 1494320 - remove unnecessary resources.manage r=tomprince  These were in place in order to delete some old, now-unused roles.  They're gone, so no need to continue to manage those namespaces.  Differential Revision: https://phabricator.services.mozilla.com/D9166|2018-10-19 03:02:08|
-|[Link to commit](https://hg.mozilla.org/build/ci-admin/pushloghtml?changeset=9d35e153d813)|Don't generate hooks for actions with cross trust-domain `.taskcluster.yml`s; r=dustin  Differential Revision: https://phabricator.services.mozilla.com/D6858|2018-09-26 02:48:44|
-|[Link to commit](https://hg.mozilla.org/build/ci-admin/pushloghtml?changeset=c88ca415a1c6)|Bug 1489181: handle input_schema in actions.yml r=aki  Differential Revision: https://phabricator.services.mozilla.com/D5683|2018-09-12 18:07:53|
+|[Link to commit](https://hg.mozilla.org/integration/autoland/pushloghtml?changeset=adf4bd858ab4)|Bug 1511252 - Clean up .tab-throbber-tabslist rules. r=dao  Differential Revision: https://phabricator.services.mozilla.com/D13687|2018-12-04 20:46:46|
+|[Link to commit](https://hg.mozilla.org/integration/autoland/pushloghtml?changeset=639759093881)|Bug 1512075 - Upgrade to Mercurial 4.8.1; r=ted  This was released a few minutes ago. It contains some fixes necessary to support partial clones.  Differential Revision: https://phabricator.services.mozilla.com/D13768|2018-12-04 23:31:26|
+|[Link to commit](https://hg.mozilla.org/integration/autoland/pushloghtml?changeset=c28a868a45f5)|Bug 1512075 - Upgrade to latest robustcheckout; r=ted  From changeset d0828787e64fa55b535c7e783bc97612f5c30cff from version-control-tools repository.  Differential Revision: https://phabricator.services.mozilla.com/D13767|2018-12-04 23:30:29|
+|[Link to commit](https://hg.mozilla.org/integration/autoland/pushloghtml?changeset=7dc99db92ea4)|Bug 1497016 - Add an API to extract tracelogger data and use this within the gecko profiler r=mstange,djvj  Add a new class to extract tracelogger data using chunked buffers and use this to write the data out to the profiler JSON output.  Copying the data in chunks lets us minimize our memory overhead when writing out to the profiler so a large array of millions of elements does not need to be allocated ahead of time.  Differential Revision: https://phabricator.services.mozilla.com/D11791|2018-12-04 21:43:38|
+|[Link to commit](https://hg.mozilla.org/integration/autoland/pushloghtml?changeset=36c4c80ddc1a)|Bug 1352355 - Fix use of wpt settings in firefox Browser, r=ato  The settngs() method is called to get a list of session-level settings that should be applied when running a test. If those settings differ from the ones applied to the previous test then we have to restart the browser. But if we set the session on the class in the settings method then at shutdown time we'll have incorrect settings. This is important for things like leak checking where the values affect the shutdown process. So instead ensure that we only set the settings on the class during startup.  Depends on D12414  Differential Revision: https://phabricator.services.mozilla.com/D13512|2018-11-30 23:17:47|
 
 |	beta	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/beta.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/beta.json)	| 
 |:----------------:|:-------------------------------------:|:---------------------------------:| 
  
 |      Repository      |                   Last commit               |    Deploy time       | 
 |:--------------------:|:-------------------------------------------:|:--------------------:| 
-|[Link to commit](https://hg.mozilla.org/releases/mozilla-beta/pushloghtml?changeset=e9b94ebee2e7)|Bug 1511232 - Adjust test expectations of test_window_define_nonconfigurable.html for non-Trunk trees. a=test-only|2018-12-03 17:08:37|
-|[Link to commit](https://hg.mozilla.org/releases/mozilla-beta/pushloghtml?changeset=f9bba4d1865f)|Backed out changeset 8461e2f532ed (bug 1488554) to prevent talos xperf permafailures on 65 beta. a=backout|2018-10-16 17:26:55|
-|[Link to commit](https://hg.mozilla.org/releases/mozilla-beta/pushloghtml?changeset=c9f6bd2a826d)|Bug 1500274 - Bump the timeout for Windows opt builds to 3hr to match other PGO-enabled builds. r=me, a=release|2018-10-22 12:47:37|
-|[Link to commit](https://hg.mozilla.org/releases/mozilla-beta/pushloghtml?changeset=e6d60ab6b013)|Bug 1510678 - Change recommended addons for Firefox 64 CFR release. r=k88hudson	a=jcristau on a CLOSED TREE  Differential Revision: https://phabricator.services.mozilla.com/D13437|2018-11-29 17:43:06|
-|[Link to commit](https://hg.mozilla.org/releases/mozilla-beta/pushloghtml?changeset=32d14aa23dce)|Bug 1502530 - Part 2: Update tzdata in ICU data files to 2018g. r=Waldo a=jcristau|2018-11-06 13:18:26|
-
-|	autoland	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/autoland.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/autoland.json)	| 
-|:----------------:|:-------------------------------------:|:---------------------------------:| 
- 
-|      Repository      |                   Last commit               |    Deploy time       | 
-|:--------------------:|:-------------------------------------------:|:--------------------:| 
-|[Link to commit](https://hg.mozilla.org/integration/autoland/pushloghtml?changeset=a002d2b3408b)|Bug 1062128 - set tooltiptext for new tab button directly for a11y reasons, r=johannh  Differential Revision: https://phabricator.services.mozilla.com/D13406|2018-12-03 18:22:05|
-|[Link to commit](https://hg.mozilla.org/integration/autoland/pushloghtml?changeset=e4e25a7e681f)|Bug 1511496 - Let the autohiding menu bar match the tab bar's height. r=mconley  Differential Revision: https://phabricator.services.mozilla.com/D13595|2018-12-03 17:03:21|
-|[Link to commit](https://hg.mozilla.org/integration/autoland/pushloghtml?changeset=cac01bf33732)|Bug 1505063 - Only flip remoteness in RDM if we're switching from the privileged content process. r=ochameau  This means that for the File URI content process, we end up closing RDM if the page navigates. This appears to be an acceptable trade-off, as this is the behaviour we've been shipping since bug 1453519 landed (Firefox 61).  Differential Revision: https://phabricator.services.mozilla.com/D13331|2018-12-03 17:00:20|
-|[Link to commit](https://hg.mozilla.org/integration/autoland/pushloghtml?changeset=1a6f9251c41f)|Bug 1491808 - [Linux/CSD/Titlebar] Force toplevel window repaint when titlebar rendering is enabled and its state changes, r=bzbarsky  Titlebar (StyleAppearance::MozWindowTitlebar) style depends on toplevel window focus and we need to redraw it when toplevel window focus changes.  Unfortunately according to https://gitlab.gnome.org/GNOME/gtk/issues/1395 the toplevel window focus can't be used here as we can have active but unfocused toplevel window during drag & drop.  Gtk+ controls window active appearance by window-state-event signal but gecko uses focus-in/out signals, so we need to repaint the titlebar when window-state-event comes  after  focus-in/out signals.  We can't call mWidgetListener->WindowActivated() (and WindowDeactivated()) as it was already called from focus-in/out handlers before window-state-event.  Depends on D13051  Differential Revision: https://phabricator.services.mozilla.com/D13052|2018-12-03 12:48:52|
-|[Link to commit](https://hg.mozilla.org/integration/autoland/pushloghtml?changeset=d1fc8c77ad7f)|Bug 1491808 - Listen on window-state-event to set titlebar active/inactive state, r=jhorak  This is a workaround for https://gitlab.gnome.org/GNOME/gtk/issues/1395 Gtk+ controls window active appearance by window-state-event signal but gecko uses focus-in/out signals.  So we need to set the the titlebar state when window-state-event comes  after  focus-in/out signals.  Differential Revision: https://phabricator.services.mozilla.com/D13051|2018-12-03 12:48:35|
-
-|	inbound	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/inbound.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/inbound.json)	| 
-|:----------------:|:-------------------------------------:|:---------------------------------:| 
- 
-|      Repository      |                   Last commit               |    Deploy time       | 
-|:--------------------:|:-------------------------------------------:|:--------------------:| 
-|[Link to commit](https://hg.mozilla.org/integration/mozilla-inbound/pushloghtml?changeset=4f08283a2e3a)|Bug 1510911 - Part 3: Backout changeset d0997972e4d4 (bug 1493563 - Part 4) for regressing performance |2018-11-29 15:50:38|
-|[Link to commit](https://hg.mozilla.org/integration/mozilla-inbound/pushloghtml?changeset=82236b4be4c9)|Bug 1510911 - Part 2: Backout changeset f8849239da42 (bug 1493563 - Part 5) for regressing performance |2018-11-29 15:46:08|
-|[Link to commit](https://hg.mozilla.org/integration/mozilla-inbound/pushloghtml?changeset=c259bf672187)|Bug 1510911 - Part 1: Backout changeset cdb8932d1d8d (bug 1493563 - Part 11) for regressing performance |2018-11-29 15:37:54|
-|[Link to commit](https://hg.mozilla.org/integration/mozilla-inbound/pushloghtml?changeset=6ff23eb2892a)|Bug 1511714 - Unbreak on platform without GeckoProfiler after bug 1509571. r=mconley|2018-12-02 09:56:00|
-|[Link to commit](https://hg.mozilla.org/integration/mozilla-inbound/pushloghtml?changeset=decb54eeaa7d)|Bug 1503175 - Restore the previous inspector layout when reopening. r=gl|2018-11-09 17:56:05|
-
-|	mozilla-central	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/mozilla-central.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/mozilla-central.json)	| 
-|:----------------:|:-------------------------------------:|:---------------------------------:| 
- 
-|      Repository      |                   Last commit               |    Deploy time       | 
-|:--------------------:|:-------------------------------------------:|:--------------------:| 
-|[Link to commit](https://hg.mozilla.org/mozilla-central/pushloghtml?changeset=60b122ce38e6)|No bug - Tagging mozilla-central 9ad82455dcee2bc1d438e46016b8db00e88758a8 with FIREFOX_BETA_65_BASE a=release DONTBUILD CLOSED TREE|2018-12-03 15:59:35|
-|[Link to commit](https://hg.mozilla.org/mozilla-central/pushloghtml?changeset=9ad82455dcee)|Bug 1510689.  Only define IsNonConfigurableReadonlyPrimitiveGlobalProp if we plan to use it.  r=peterv a=Aryx,beta-fix|2018-12-03 14:14:15|
-|[Link to commit](https://hg.mozilla.org/mozilla-central/pushloghtml?changeset=01d0813d8203)|Merge inbound to mozilla-central.  a=merge|2018-12-03 09:30:40|
-|[Link to commit](https://hg.mozilla.org/mozilla-central/pushloghtml?changeset=290a2b092c01)|Bug 1452527: Un-skip reftest svg/outline.html on mac/linux, and mark it as fuzzy in general. (no review, just adjusting test annotation)  The fuzzy() annotation here is using the max-difference from the Windows failures in bug 1452527, and the number-of-mismatching-pixels from mac/linux failures in bug 1503525.|2018-12-03 01:09:25|
-|[Link to commit](https://hg.mozilla.org/mozilla-central/pushloghtml?changeset=016950978d66)|Revert "Backed out changeset d0fb1493b28b (bug 1511717) for devtools failures in browser_webconsole_eval_in_debugger_stackframe.js"  This reverts commit fd12a44e915d4e06f4509588ff4667dd9646e2dd. |2018-12-03 00:33:06|
-
-|	mozilla-release	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/mozilla-release.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/mozilla-release.json)	| 
-|:----------------:|:-------------------------------------:|:---------------------------------:| 
- 
-|      Repository      |                   Last commit               |    Deploy time       | 
-|:--------------------:|:-------------------------------------------:|:--------------------:| 
-|[Link to commit](https://hg.mozilla.org/releases/mozilla-release/pushloghtml?changeset=321f1fb3b41f)|Bug 1510678 - Change recommended addons for Firefox 64 CFR release. r=k88hudson	a=jcristau  Differential Revision: https://phabricator.services.mozilla.com/D13437|2018-11-29 17:43:06|
-|[Link to commit](https://hg.mozilla.org/releases/mozilla-release/pushloghtml?changeset=fa624a63f7d9)|Bug 1502530 - Part 2: Update tzdata in ICU data files to 2018g. r=Waldo a=jcristau|2018-11-06 13:18:26|
-|[Link to commit](https://hg.mozilla.org/releases/mozilla-release/pushloghtml?changeset=4498eed63436)|Bug 1502530 - Part 1: Update tzdata updater to use new location. r=Waldo a=jcristau|2018-11-06 10:48:56|
-|[Link to commit](https://hg.mozilla.org/releases/mozilla-release/pushloghtml?changeset=d27d733d06cf)|Bug 1507433 - Avoid shape teleporting if any uncacheable prototypes. r=jandem a=jcristau  These cases are rare and uncacheable prototype shapes are tricky to get right so simplify code instead. The impact is that accessing non-own properties of an object that mutates its prototype will have a few more shape / group guards than are strictly needed.  Differential Revision: https://phabricator.services.mozilla.com/D12806|2018-11-27 13:10:49|
-|[Link to commit](https://hg.mozilla.org/releases/mozilla-release/pushloghtml?changeset=f4770816becd)|Bug 1509810 - ASR Snippets: FxA signup template issues. r=ursula a=jcristau  Differential Revision: https://phabricator.services.mozilla.com/D13445|2018-11-29 17:49:59|
-
-|	comm-esr60	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/comm-esr60.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/comm-esr60.json)	| 
-|:----------------:|:-------------------------------------:|:---------------------------------:| 
- 
-|      Repository      |                   Last commit               |    Deploy time       | 
-|:--------------------:|:-------------------------------------------:|:--------------------:| 
-|[Link to commit](https://hg.mozilla.org/releases/comm-esr60/pushloghtml?changeset=c088b10cdb9d)|No bug - Pin mozilla-esr60 version for release. a=jorgk|2018-08-15 21:36:04|
-|[Link to commit](https://hg.mozilla.org/releases/comm-esr60/pushloghtml?changeset=17f398c01f88)|Bug 1510913 - Remove the chromeclass-toolbar's unneeded margin-inline-start. r+a=jorgk|2018-12-01 10:12:18|
-|[Link to commit](https://hg.mozilla.org/releases/comm-esr60/pushloghtml?changeset=04fee377d47e)|Bug 1509483 - Set a background color for #calendar-task-details-container on macOS. r+a=philipp|2018-11-23 18:28:23|
-|[Link to commit](https://hg.mozilla.org/releases/comm-esr60/pushloghtml?changeset=fea596d791df)|Automatic version bump CLOSED TREE NO BUG a=release|2018-11-29 23:29:47|
-|[Link to commit](https://hg.mozilla.org/releases/comm-esr60/pushloghtml?changeset=bd67cdfc2e40)|No bug - Tagging 0ba73c30a3d9f213323766057d2176cd253efdd3 with THUNDERBIRD_60_3_2_BUILD1, THUNDERBIRD_60_3_2_RELEASE a=release CLOSED TREE|2018-11-29 23:29:46|
-
-|	mozilla-esr60	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/mozilla-esr60.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/mozilla-esr60.json)	| 
-|:----------------:|:-------------------------------------:|:---------------------------------:| 
- 
-|      Repository      |                   Last commit               |    Deploy time       | 
-|:--------------------:|:-------------------------------------------:|:--------------------:| 
-|[Link to commit](https://hg.mozilla.org/releases/mozilla-esr60/pushloghtml?changeset=5311a17b136e)|Bug 1510183 - Make HTMLEditor treat empty string attribute of style as nullptr of nsAtom rather than nsGkAtoms::_empty. r=m_kato a=jorgk DONTBUILD  After fixing bug 1427060, HTMLEditor treats attribute of style as nullptr. However, if empty string is used to call NS_Atomize(), it returns nsGkAtoms::_empty.  Therefore, HTMLEditor fails to check whether attribute is specified or not with nullptr check since some root callers sets nsGkAtoms::_empty instead of nullptr.  This patch makes HTMLEditor always use nullptr for empty string of attribute of style with wrapping NS_Atomize() with AtomzieAttribute().  Additionally, for safer change, this patch makes PropItem and TypeInState treat nsGkAtom::_empty as nullptr.|2018-11-30 01:21:59|
-|[Link to commit](https://hg.mozilla.org/releases/mozilla-esr60/pushloghtml?changeset=6cc5fc0eaeaf)|Update configs. IGNORE BROKEN CHANGESETS CLOSED TREE NO BUG a=release ba=release|2018-12-03 16:38:03|
-|[Link to commit](https://hg.mozilla.org/releases/mozilla-esr60/pushloghtml?changeset=d428d2b8f585)|Bug 1511495 - Update Firefox ESR60 to NSS 3.36.6. r=jcj, a=lizzard UPGRADE_NSS_RELEASE|2018-12-02 21:32:17|
-|[Link to commit](https://hg.mozilla.org/releases/mozilla-esr60/pushloghtml?changeset=42791ed04461)|Bug 1505911 - Use IsAlpha/IsDigit instead of IsAsciiAlpha/IsAsciiDigit for full Unicode support. r=valentin a=jorgk DONTBUILD|2013-09-01 09:23:43|
-|[Link to commit](https://hg.mozilla.org/releases/mozilla-esr60/pushloghtml?changeset=3e8c9f8c5307)|Bug 1351940 - [marionette] Only convert a valid outerWindowID to a string. r=ato, a=test-only  Differential Revision: https://phabricator.services.mozilla.com/D13206|2018-11-28 20:48:42|
+|[Link to commit](https://hg.mozilla.org/releases/mozilla-beta/pushloghtml?changeset=1f6ce017121d)|Automatic version bump CLOSED TREE NO BUG a=release DONTBUILD|2018-12-04 19:46:27|
+|[Link to commit](https://hg.mozilla.org/releases/mozilla-beta/pushloghtml?changeset=002917d5ac54)|No bug - Tagging 34fd146e3a2cae7f729e04d2048cc176958505b0 with DEVEDITION_65_0b1_RELEASE a=release CLOSED TREE DONTBUILD|2018-12-04 19:46:23|
+|[Link to commit](https://hg.mozilla.org/releases/mozilla-beta/pushloghtml?changeset=b852717708af)|No bug - Tagging cfb1a45b322e63746074f79741837063fc3651e0 with FENNEC_64_0b15_RELEASE a=release CLOSED TREE DONTBUILD|2018-12-04 18:18:32|
+|[Link to commit](https://hg.mozilla.org/releases/mozilla-beta/pushloghtml?changeset=88f8cfa6a977)|No bug - Tagging 34fd146e3a2cae7f729e04d2048cc176958505b0 with DEVEDITION_65_0b1_BUILD2 a=release CLOSED TREE DONTBUILD|2018-12-04 16:26:35|
+|[Link to commit](https://hg.mozilla.org/releases/mozilla-beta/pushloghtml?changeset=34fd146e3a2c)|Bug 1511988 - Convert aboutNetworking.ftl to LF line ending r=Pike a=release-bustage on CLOSED TREE  Differential Revision: https://phabricator.services.mozilla.com/D13730|2018-12-04 15:12:32|
 
 |	braindump	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/braindump.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/braindump.json)	| 
 |:----------------:|:-------------------------------------:|:---------------------------------:| 
@@ -132,6 +33,116 @@
 |[Link to commit](https://hg.mozilla.org/build/braindump/pushloghtml?changeset=56f54e63a30d)|Bug 1500897 - taskgraph-diff: Add "hg_branch" data|2018-10-23 14:46:00|
 |[Link to commit](https://hg.mozilla.org/build/braindump/pushloghtml?changeset=b5f69b20179d)|No bug - Remove check_servo filter r=tomprince  Deleted in https://hg.mozilla.org/mozilla-central/rev/6c2ca1a524e6|2018-10-26 13:07:04|
 
+|	ci-admin	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/ci-admin.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/ci-admin.json)	| 
+|:----------------:|:-------------------------------------:|:---------------------------------:| 
+ 
+|      Repository      |                   Last commit               |    Deploy time       | 
+|:--------------------:|:-------------------------------------------:|:--------------------:| 
+|[Link to commit](https://hg.mozilla.org/build/ci-admin/pushloghtml?changeset=99d859a7a655)|Bug 1492665 - add modify_resources support r=Callek,bstack  Differential Revision: https://phabricator.services.mozilla.com/D6933|2018-10-22 17:52:14|
+|[Link to commit](https://hg.mozilla.org/build/ci-admin/pushloghtml?changeset=241f75b5d808)|Bug 1492665 - add support for environments.yml r=Callek,bstack  Differential Revision: https://phabricator.services.mozilla.com/D6932|2018-10-22 17:52:13|
+|[Link to commit](https://hg.mozilla.org/build/ci-admin/pushloghtml?changeset=d1796b61fbd0)|Bug 1494320 - remove unnecessary resources.manage r=tomprince  These were in place in order to delete some old, now-unused roles.  They're gone, so no need to continue to manage those namespaces.  Differential Revision: https://phabricator.services.mozilla.com/D9166|2018-10-19 03:02:08|
+|[Link to commit](https://hg.mozilla.org/build/ci-admin/pushloghtml?changeset=9d35e153d813)|Don't generate hooks for actions with cross trust-domain `.taskcluster.yml`s; r=dustin  Differential Revision: https://phabricator.services.mozilla.com/D6858|2018-09-26 02:48:44|
+|[Link to commit](https://hg.mozilla.org/build/ci-admin/pushloghtml?changeset=c88ca415a1c6)|Bug 1489181: handle input_schema in actions.yml r=aki  Differential Revision: https://phabricator.services.mozilla.com/D5683|2018-09-12 18:07:53|
+
+|	ci-configuration	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/ci-configuration.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/ci-configuration.json)	| 
+|:----------------:|:-------------------------------------:|:---------------------------------:| 
+ 
+|      Repository      |                   Last commit               |    Deploy time       | 
+|:--------------------:|:-------------------------------------------:|:--------------------:| 
+|[Link to commit](https://hg.mozilla.org/build/ci-configuration/pushloghtml?changeset=e9634d8942ca)|Bug 1510441: Use sparse profile in cron tasks; r=gps  Differential Revision: https://phabricator.services.mozilla.com/D13141|2018-11-30 13:01:34|
+|[Link to commit](https://hg.mozilla.org/build/ci-configuration/pushloghtml?changeset=13cbc18135d2)|Bug 1503894 - reenable taskcluster-cron for comm-central repo. r=tomprince  This goes along with a .cron.yml update in comm-central that removes the periodic-file-update cron configuration. (Bug 1499590 comment 15)  This will get comm-central nightly builds working again.  Differential Revision: https://phabricator.services.mozilla.com/D10959|2018-11-06 21:44:29|
+|[Link to commit](https://hg.mozilla.org/build/ci-configuration/pushloghtml?changeset=38144ac82b0a)|Bug 1503894 - disable taskcluster-cron for comm-central repos r=tomprince  The cron hook expects that it is checking out a gecko tree.  Robustcheckout kind of loses its mind when it clones mozilla-unified, then finds no ancestor in common with a comm-central pull.  Differential Revision: https://phabricator.services.mozilla.com/D10595|2018-11-01 18:52:02|
+|[Link to commit](https://hg.mozilla.org/build/ci-configuration/pushloghtml?changeset=48d479b3411b)|Bug 1502976 - upgrade decision image to the latest r=tomprince  Differential Revision: https://phabricator.services.mozilla.com/D10124|2018-10-29 21:38:55|
+|[Link to commit](https://hg.mozilla.org/build/ci-configuration/pushloghtml?changeset=d56b6be4c4c1)|Bug 1499590 - Enable taskcluster-cron on additional comm- repos. r=dustin  The periodic-file-updates cron task is meant to run on comm-central, comm-beta, and comm-esr60 like it's mozilla- counterpart task.  Differential Revision: https://phabricator.services.mozilla.com/D9860|2018-10-26 17:55:26|
+
+|	comm-esr60	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/comm-esr60.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/comm-esr60.json)	| 
+|:----------------:|:-------------------------------------:|:---------------------------------:| 
+ 
+|      Repository      |                   Last commit               |    Deploy time       | 
+|:--------------------:|:-------------------------------------------:|:--------------------:| 
+|[Link to commit](https://hg.mozilla.org/releases/comm-esr60/pushloghtml?changeset=e4d520b5dc17)|Backed out changeset a6e340fe4c07 and 7fe1827e6b39 (bug 1482040) for causing address book and auto-complete slowness (bug 1511885). a=backout  Backed out changeset a6e340fe4c07 (bug 1482040) Backed out changeset 7fe1827e6b39 (bug 1482040)|2018-12-04 17:38:23|
+|[Link to commit](https://hg.mozilla.org/releases/comm-esr60/pushloghtml?changeset=d6e310cff401)|Backed out changeset 73ed0515afc2 (bug 1490626) for causing address book and auto-complete slowness (bug 1511885). a=backout|2018-12-04 17:36:10|
+|[Link to commit](https://hg.mozilla.org/releases/comm-esr60/pushloghtml?changeset=fe462e7a581c)|No bug - Pin mozilla-esr60 version for release. a=jorgk|2018-12-03 21:30:47|
+|[Link to commit](https://hg.mozilla.org/releases/comm-esr60/pushloghtml?changeset=c088b10cdb9d)|No bug - Pin mozilla-esr60 version for release. a=jorgk|2018-08-15 21:36:04|
+|[Link to commit](https://hg.mozilla.org/releases/comm-esr60/pushloghtml?changeset=17f398c01f88)|Bug 1510913 - Remove the chromeclass-toolbar's unneeded margin-inline-start. r+a=jorgk|2018-12-01 10:12:18|
+
+|	inbound	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/inbound.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/inbound.json)	| 
+|:----------------:|:-------------------------------------:|:---------------------------------:| 
+ 
+|      Repository      |                   Last commit               |    Deploy time       | 
+|:--------------------:|:-------------------------------------------:|:--------------------:| 
+|[Link to commit](https://hg.mozilla.org/integration/mozilla-inbound/pushloghtml?changeset=84a17995db6f)|Bug 1512082 - Add TRY_SELECTOR env to templates expected value. r=me|2018-12-04 22:42:41|
+|[Link to commit](https://hg.mozilla.org/integration/mozilla-inbound/pushloghtml?changeset=8860aa6f15ed)|Merge mozilla-central to mozilla-inbound. a=merge on a CLOSED TREE|2018-12-04 22:01:48|
+|[Link to commit](https://hg.mozilla.org/integration/mozilla-inbound/pushloghtml?changeset=0a65dda20ade)|Merge mozilla-inbound to mozilla-central a=merge|2018-12-04 21:53:17|
+|[Link to commit](https://hg.mozilla.org/integration/mozilla-inbound/pushloghtml?changeset=55b77d1533ab)|Merge autoland to mozilla-central a=merge|2018-12-04 21:50:32|
+|[Link to commit](https://hg.mozilla.org/integration/mozilla-inbound/pushloghtml?changeset=4021b5422562)|Bug 1511376 - Firefox crashes during startup when executed from tempdir r=Alex_Gaynor  Change nsMacUtilsImpl::GetAppPath() to not depend on the app bundle ending in ".app".  Differential Revision: https://phabricator.services.mozilla.com/D13682|2018-12-04 19:02:06|
+
+|	mozilla-build	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/mozilla-build.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/mozilla-build.json)	| 
+|:----------------:|:-------------------------------------:|:---------------------------------:| 
+ 
+|      Repository      |                   Last commit               |    Deploy time       | 
+|:--------------------:|:-------------------------------------------:|:--------------------:| 
+|[Link to commit](https://hg.mozilla.org/mozilla-build/pushloghtml?changeset=c5a55cf36958)|Bug 1501406 - Update vswhere to version 2.5.2.|2018-10-23 19:12:46|
+|[Link to commit](https://hg.mozilla.org/mozilla-build/pushloghtml?changeset=400ec3910570)|Bug 1501403 - Update UPX to version 3.95.|2018-10-23 19:08:31|
+|[Link to commit](https://hg.mozilla.org/mozilla-build/pushloghtml?changeset=5b1cf2c85207)|Bug 1501399 - Update emacs to version 26.1.|2018-10-23 18:57:20|
+|[Link to commit](https://hg.mozilla.org/mozilla-build/pushloghtml?changeset=d45e1040d212)|Bug 1501395 - Update the bundled sqlite3 DLL to 3.25.2.|2018-10-23 18:55:33|
+|[Link to commit](https://hg.mozilla.org/mozilla-build/pushloghtml?changeset=1af5fbf9b763)|Bug 1501395 - Update python3 to version 3.7.1.|2018-10-23 18:53:23|
+
+|	mozilla-central	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/mozilla-central.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/mozilla-central.json)	| 
+|:----------------:|:-------------------------------------:|:---------------------------------:| 
+ 
+|      Repository      |                   Last commit               |    Deploy time       | 
+|:--------------------:|:-------------------------------------------:|:--------------------:| 
+|[Link to commit](https://hg.mozilla.org/mozilla-central/pushloghtml?changeset=0a65dda20ade)|Merge mozilla-inbound to mozilla-central a=merge|2018-12-04 21:53:17|
+|[Link to commit](https://hg.mozilla.org/mozilla-central/pushloghtml?changeset=e77b8931ae7a)|Bug 1511692 - suppress warning for NS_BASE_STREAM_CLOSED from base streams Available() call. r=baku|2018-12-03 22:48:00|
+|[Link to commit](https://hg.mozilla.org/mozilla-central/pushloghtml?changeset=a5e9c1404b37)|Merge mozilla-central to mozilla-inbound. a=merge|2018-12-04 09:45:55|
+|[Link to commit](https://hg.mozilla.org/mozilla-central/pushloghtml?changeset=23f6608c96b8)|Bug 1511894 - Re-enable wasm abort.any.js on fennec wpt r=me a=testonly|2018-12-03 22:37:58|
+|[Link to commit](https://hg.mozilla.org/mozilla-central/pushloghtml?changeset=570521ec4d0f)|Merge mozilla-central to mozilla-inbound.  a=merge CLOSED TREE|2018-12-03 21:53:09|
+
+|	mozilla-esr60	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/mozilla-esr60.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/mozilla-esr60.json)	| 
+|:----------------:|:-------------------------------------:|:---------------------------------:| 
+ 
+|      Repository      |                   Last commit               |    Deploy time       | 
+|:--------------------:|:-------------------------------------------:|:--------------------:| 
+|[Link to commit](https://hg.mozilla.org/releases/mozilla-esr60/pushloghtml?changeset=27d80d202f78)|Bug 1492128: [mozrelease] Tweak buglist email to be nicely formated and not use URL shortener; r=mtabara a=release  Differential Revision: https://phabricator.services.mozilla.com/D11096|2018-11-06 18:54:20|
+|[Link to commit](https://hg.mozilla.org/releases/mozilla-esr60/pushloghtml?changeset=ce2b8fd01f4c)|Bug 1492128: [mozrelease] Fix typo in taskcluster proxy configuration; r=me|2018-11-01 20:21:12|
+|[Link to commit](https://hg.mozilla.org/releases/mozilla-esr60/pushloghtml?changeset=3832eeb1e124)|Bug 1492128: [mozrelease] Pass repository to buglist commands; r=mtabara  Differential Revision: https://phabricator.services.mozilla.com/D10156|2018-10-30 18:21:49|
+|[Link to commit](https://hg.mozilla.org/releases/mozilla-esr60/pushloghtml?changeset=0ad7b5576268)|Bug 1492128: [mozrelease] Send an email when a release starts with a bug list; r=mtabara  Differential Revision: https://phabricator.services.mozilla.com/D10155|2018-10-30 21:04:00|
+|[Link to commit](https://hg.mozilla.org/releases/mozilla-esr60/pushloghtml?changeset=1a026a44500b)|Bug 1492128: [mozrelease] Add command to generate buglist for a given release; r=mtabara  Differential Revision: https://phabricator.services.mozilla.com/D10154|2018-10-30 18:21:40|
+
+|	mozilla-release	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/mozilla-release.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/mozilla-release.json)	| 
+|:----------------:|:-------------------------------------:|:---------------------------------:| 
+ 
+|      Repository      |                   Last commit               |    Deploy time       | 
+|:--------------------:|:-------------------------------------------:|:--------------------:| 
+|[Link to commit](https://hg.mozilla.org/releases/mozilla-release/pushloghtml?changeset=26d700d8010a)|Bug 1499418 - Refactor and move Fennec's telemetry classes to geckoview/. r=jchen, a=RyanVM|2018-11-13 14:29:21|
+|[Link to commit](https://hg.mozilla.org/releases/mozilla-release/pushloghtml?changeset=348872e1c4fe)|Bug 1499418 - Add GeckoView page load and startup performance telemetry probes. r=snorp,chutten,jchen, a=RyanVM|2018-11-13 14:39:11|
+|[Link to commit](https://hg.mozilla.org/releases/mozilla-release/pushloghtml?changeset=626d7b63b958)|No bug - Tagging 80a34446b74a1ee3d0d5e3bf69232b8b0a5e64ab with FIREFOX_64_0_BUILD1 a=release CLOSED TREE DONTBUILD|2018-12-03 23:36:36|
+|[Link to commit](https://hg.mozilla.org/releases/mozilla-release/pushloghtml?changeset=80a34446b74a)|Bug 1510985 - Remove Event.returnValue temporarily in 64. r=smaug a=jcristau  Event.returnValue causes breaking a bank application.  The reason of the breakage is, the web app assumes that Event.returnValue is available only on IE and it hits same incompatibility issue with window.event (bug 1479964). Additionally, the app may be used in various domains including in intranet. Therefore, we cannot disable it with blacklist of domains like other similar changes.  Fortunately, we can ship new keypress event behaviors which is tracked by bug 1479964 in 65.  So, for backward compatibility with 62 or earlier, we should temporarily disable Event.returnValue in 64.  But unfortunately, this was introduced in 63.  So, if some web apps have started to use this legacy attribute, we need to contact their vendors, though.|2018-12-03 20:24:39|
+|[Link to commit](https://hg.mozilla.org/releases/mozilla-release/pushloghtml?changeset=c814d6d044cc)|Backed out changeset 5856e2411504 (bug 1510985) for landing a partial patch|2018-12-03 20:23:07|
+
+|	try	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/try.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/hg_files/try.json)	| 
+|:----------------:|:-------------------------------------:|:---------------------------------:| 
+ 
+|      Repository      |                   Last commit               |    Deploy time       | 
+|:--------------------:|:-------------------------------------------:|:--------------------:| 
+|[Link to commit](https://hg.mozilla.org/try/pushloghtml?changeset=a5f93b9a1704)|try: -b do -p win32,win64,linux64,linux -u web-platform-tests-e10s-1[linux64-stylo,Ubuntu,10.10,Windows 10],web-platform-tests-1[linux64-stylo,Ubuntu,10.10,Windows 10] -t none --artifact --rebuild 10 --try-test-paths web-platform-tests:testing/web-platform/tests/storage/estimate-indexeddb.https.any.js|2018-12-05 01:44:28|
+|[Link to commit](https://hg.mozilla.org/try/pushloghtml?changeset=f7443fe3e23a)|try: -b do -p win32,win64,linux64,linux -u web-platform-tests-e10s-1[linux64-stylo,Ubuntu,10.10,Windows 10],web-platform-tests-1[linux64-stylo,Ubuntu,10.10,Windows 10] -t none --artifact --rebuild 10 --try-test-paths web-platform-tests:testing/web-platform/tests/storage/estimate-usage-details-application-cache.https.tentative.html web-platform-tests:testing/web-platform/tests/storage/estimate-usage-details-caches.https.tentative.any.js web-platform-tests:testing/web-platform/tests/storage/estimate-usage-details-service-workers.https.tentative.window.js|2018-12-05 01:17:04|
+|[Link to commit](https://hg.mozilla.org/try/pushloghtml?changeset=40bc2390bb96)|Bug 1512098 [wpt PR 14362] - Update wpt metadata, a=testonly  wpt-pr: 14362 wpt-type: metadata |2018-12-05 01:16:47|
+|[Link to commit](https://hg.mozilla.org/try/pushloghtml?changeset=6f916b0e97a5)|try: -b do -p win32,win64,linux64,linux -u web-platform-tests-e10s-1[linux64-stylo,Ubuntu,10.10,Windows 10],web-platform-tests-1[linux64-stylo,Ubuntu,10.10,Windows 10] -t none --artifact --try-test-paths web-platform-tests:testing/web-platform/tests/IndexedDB/idb-explicit-commit.any.js|2018-12-05 01:02:28|
+|[Link to commit](https://hg.mozilla.org/try/pushloghtml?changeset=a39ab7b3c0a0)|Bug 1512104 [wpt PR 14363] - [IndexedDB] Testing ordering and error handling for transaction.commit, a=testonly    Tests that transaction ordering is consistent, even if a transaction   calls commit().   Tests that request errors cause a commit()-ed transaction to abort.  The second case seems to be broken in our implementation.  R=andreasbutler@google.com, cmp@chromium.org  Bug: 911877 Change-Id: I47da6ce9d350f6c47afcd02cf808d4fefb5f013f  wpt-commit: 184fcfe5959cc7fafd01f90ddc9c98ad767eaa18 wpt-pr: 14363 |2018-12-05 01:00:32|
+
+|	addonscript	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/addonscript.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/addonscript.json)	| 
+|:----------------:|:-------------------------------------:|:---------------------------------:| 
+ 
+|      Repository      |                   Last commit               |    Deploy time       | 
+|:--------------------:|:-------------------------------------------:|:--------------------:| 
+|[Link to commit](https://github.com/mozilla-releng/addonscript/commit/e9dd5dac0a21fe1943165416ac2eda1ff4b85792)|Merge pull request #51 from Callek/one_dot_oh  Bump to 1.0 and align setup.py requirements with requirements.txt.in|2018-05-17 13:58:03|
+|[Link to commit](https://github.com/mozilla-releng/addonscript/commit/05578d0c3f916e9be44fd825cf94ed201c44dea2)|Bump to 1.0 and align setup.py requirements with requirements.txt.in|2018-05-15 16:57:02|
+|[Link to commit](https://github.com/mozilla-releng/addonscript/commit/24408061c1ff8cd2799a1865c56ce8659101bb3f)|Update scriptworker from 11.0.0 to 11.1.0|2018-05-17 09:57:29|
+|[Link to commit](https://github.com/mozilla-releng/addonscript/commit/34f18115164aec34814b23cf17dddbe99bd2efa1)|Update scriptworker from 11.0.0 to 11.1.0|2018-05-17 09:57:28|
+|[Link to commit](https://github.com/mozilla-releng/addonscript/commit/b73b44300f0558a663ed37e0a9eac9ff0347b5b7)|Update virtualenv from 15.2.0 to 16.0.0|2018-05-17 00:27:29|
+
 |	balrogscript	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/balrogscript.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/balrogscript.json)	| 
 |:----------------:|:-------------------------------------:|:---------------------------------:| 
  
@@ -142,28 +153,6 @@
 |[Link to commit](https://github.com/mozilla-releng/balrogscript/commit/69fc7601f1ea569c9e40640f78b56c7d97bff71f)|Add code to create multiple blobs with different `updateLine` info.|2018-11-22 20:42:08|
 |[Link to commit](https://github.com/mozilla-releng/balrogscript/commit/7f820677b714da97f9eb5ab0298fe022a6a289ca)|Add code to update multiple blobs with different suffixes.|2018-11-22 20:41:18|
 |[Link to commit](https://github.com/mozilla-releng/balrogscript/commit/af210e95451e950d9151e745ccc4d0f3965b91d7)|Merge pull request #42 from tp-tc/tools-tests  Import some tests.|2018-11-22 18:42:07|
-
-|	shipitscript	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/shipitscript.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/shipitscript.json)	| 
-|:----------------:|:-------------------------------------:|:---------------------------------:| 
- 
-|      Repository      |                   Last commit               |    Deploy time       | 
-|:--------------------:|:-------------------------------------------:|:--------------------:| 
-|[Link to commit](https://github.com/mozilla-releng/shipitscript/commit/4c89c1b239fd8415e1225ba738ba820342bd8081)|Add support for Ship-it v2 (#14)|2018-11-21 16:33:53|
-|[Link to commit](https://github.com/mozilla-releng/shipitscript/commit/0c892801fc9ad80e3a12b80ab69a7e3527ec0eea)|Address comments|2018-11-21 15:44:59|
-|[Link to commit](https://github.com/mozilla-releng/shipitscript/commit/3033ccfe619289bfd022df1250a924f995ac33b8)|Revert local temp canges|2018-11-20 04:44:21|
-|[Link to commit](https://github.com/mozilla-releng/shipitscript/commit/fb22074bb0e5bc26373cf5c2305e89f2a45eae25)|Bump version to 3.0.0|2018-11-20 04:24:43|
-|[Link to commit](https://github.com/mozilla-releng/shipitscript/commit/2032f7bfc6c1629fa783a1af52f42ac51668d7f2)|Add support for masrk as shipped v2|2018-11-20 04:20:35|
-
-|	services	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/services.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/services.json)	| 
-|:----------------:|:-------------------------------------:|:---------------------------------:| 
- 
-|      Repository      |                   Last commit               |    Deploy time       | 
-|:--------------------:|:-------------------------------------------:|:--------------------:| 
-|[Link to commit](https://github.com/mozilla/release-services/commit/ae0004b50d4d2252d5b8ed3d3d3aa232a1412d14)|staticanalysis/bot: Filter clang-format publishable issues by their path. (#1689)|2018-11-20 15:36:16|
-|[Link to commit](https://github.com/mozilla/release-services/commit/f5434b1aff3d78db8bfceae7cfa872382c4b1d9f)|codecoverage/backend: Add test for codecoverage backend with mocked rq and Redis (#1673)|2018-11-20 11:57:13|
-|[Link to commit](https://github.com/mozilla/release-services/commit/88b939c265b26fe9e960d7a3361648d9ea522af6)|uplift/bot: Add a BUGZILLA_COMMENT_ONLY setting in order to report failed uplifts without cancelling requests. (#1680)|2018-11-20 09:34:34|
-|[Link to commit](https://github.com/mozilla/release-services/commit/3399eed333cb502e46c5a7b83f3673d0fb4faafb)|shipit/frontent: add testing config (#1687)  At this point it is the same as staging.js|2018-11-20 01:39:45|
-|[Link to commit](https://github.com/mozilla/release-services/commit/37bc7cafe221c5cea7d33041125d95312fe7757f)|shipit/api: update release status (#1688)  In the future we will need to update the release status explicitly from  a in-tree scheduled task, so we mark a release as completed only after  all required tasks are done (bouncer, tests, etc).|2018-11-19 20:45:16|
 
 |	beetmoverscript	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/beetmoverscript.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/beetmoverscript.json)	| 
 |:----------------:|:-------------------------------------:|:---------------------------------:| 
@@ -187,45 +176,44 @@
 |[Link to commit](https://github.com/mozilla-releng/bouncerscript/commit/3409785ede3fa3a0377b8cee3e5bca3ab49757ed)|Merge branch 'master' into msi|2018-11-10 09:49:19|
 |[Link to commit](https://github.com/mozilla-releng/bouncerscript/commit/a88e5f643bd2671cc47c6240a2794d8d11a5d792)|Fix logging (#45)|2018-11-10 09:49:02|
 
-|	treescript	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/treescript.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/treescript.json)	| 
+|	build-cloud-tools	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/build-cloud-tools.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/build-cloud-tools.json)	| 
 |:----------------:|:-------------------------------------:|:---------------------------------:| 
  
 |      Repository      |                   Last commit               |    Deploy time       | 
 |:--------------------:|:-------------------------------------------:|:--------------------:| 
-|[Link to commit](https://github.com/mozilla-releng/treescript/commit/5513bb6bfd14c076aadbf275c2a9f3cffb3fb30a)|Bump version.|2018-10-31 21:21:07|
-|[Link to commit](https://github.com/mozilla-releng/treescript/commit/b34cbe8f210f55b9e29eb438f1cd34b6390250a7)|Bug 1495464: Update hg.mozilla.org fingerprint.|2018-10-31 21:18:25|
-|[Link to commit](https://github.com/mozilla-releng/treescript/commit/4f9700637f3c90610207fea918f15e10b6dfa44b)|Update virtualenv from 16.0.0 to 16.1.0|2018-10-31 16:31:24|
-|[Link to commit](https://github.com/mozilla-releng/treescript/commit/26f431b8a1c975156ca16e7ba4416203e912c89c)|Update virtualenv from 16.0.0 to 16.1.0|2018-10-31 16:31:22|
-|[Link to commit](https://github.com/mozilla-releng/treescript/commit/340147bcf13fd0407c26491501ea6c8fe162598d)|Update pyparsing from 2.2.0 to 2.3.0|2018-10-31 08:27:23|
+|[Link to commit](https://github.com/mozilla-releng/build-cloud-tools/commit/3962e62c72251ae9fc531bdb5b14ba40243a5b70)|Merge branch 'La0-buildhub-cert'|2018-12-04 16:30:17|
+|[Link to commit](https://github.com/mozilla-releng/build-cloud-tools/commit/7fe44bf80d48b949c4d65c7642e3e4b69780af84)|Add CNAME record for DigiCert on buildhub.moz.tools|2018-12-04 15:48:33|
+|[Link to commit](https://github.com/mozilla-releng/build-cloud-tools/commit/cb2ede208a3dda6df742eb0f251827762931f1d1)|Merge branch 'La0-buildhub'|2018-11-29 02:03:48|
 
-|	ship-it	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/ship-it.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/ship-it.json)	| 
+|	build-puppet	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/build-puppet.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/build-puppet.json)	| 
 |:----------------:|:-------------------------------------:|:---------------------------------:| 
  
 |      Repository      |                   Last commit               |    Deploy time       | 
 |:--------------------:|:-------------------------------------------:|:--------------------:| 
-|[Link to commit](https://github.com/mozilla-releng/ship-it/commit/f8d9c823a7fc598ba5e6623dd1f4e65c1de38393)|Add comment about syncing v1 and v2 configs (#246)|2018-11-30 19:20:47|
-|[Link to commit](https://github.com/mozilla-releng/ship-it/commit/f1a6646f20ef404c2667d3b714c3ef90b6719546)|Bug 1511159 - Disable firefox releases (#245)|2018-11-30 17:07:43|
+|[Link to commit](https://github.com/mozilla-releng/build-puppet/commit/9f3cf327c3a20d1954ee2627a15b2e8dfa86ea8d)|Force reboot linux workers (#305)    Force reboot linux workers      Force reboot linux workers      Force reboot linux workers      Force reboot linux workers      Create a separate reboot command for OSX and Linux workers      Create a separate reboot command for OSX and Linux workers      Create a separate reboot command for OSX and Linux workers|2018-12-03 08:28:30|
+|[Link to commit](https://github.com/mozilla-releng/build-puppet/commit/6d735b7ae012510bd96641ae01587eefa19fa744)|Bug 1511145: don't handle Firefox in releaserunner3 (#316)  Using fake values in case we don't hablde empty arrays properly|2018-11-30 17:10:54|
+|[Link to commit](https://github.com/mozilla-releng/build-puppet/commit/0b8d96d712cfc710e2ca3d08ecaa5682369be068)|Bump scriptworker to 17.0.1 (#315)|2018-11-29 17:12:10|
+|[Link to commit](https://github.com/mozilla-releng/build-puppet/commit/de413d0e22b0f5d478efc9dc1ef5dc3233f1eec3)|Merge pull request #312 from mitchhentges/pushapk-mobile-dep-settings  Adds mobile-dep pushapk env config|2018-11-28 23:14:51|
+|[Link to commit](https://github.com/mozilla-releng/build-puppet/commit/3f41e7d42861eab53e8533a9ade6cfce509e12d8)|Adds note that taskcluster_client_id should be simplified|2018-11-28 21:17:31|
 
-|	addonscript	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/addonscript.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/addonscript.json)	| 
+|	mozapkpublisher	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/mozapkpublisher.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/mozapkpublisher.json)	| 
 |:----------------:|:-------------------------------------:|:---------------------------------:| 
  
 |      Repository      |                   Last commit               |    Deploy time       | 
 |:--------------------:|:-------------------------------------------:|:--------------------:| 
-|[Link to commit](https://github.com/mozilla-releng/addonscript/commit/e9dd5dac0a21fe1943165416ac2eda1ff4b85792)|Merge pull request #51 from Callek/one_dot_oh  Bump to 1.0 and align setup.py requirements with requirements.txt.in|2018-05-17 13:58:03|
-|[Link to commit](https://github.com/mozilla-releng/addonscript/commit/05578d0c3f916e9be44fd825cf94ed201c44dea2)|Bump to 1.0 and align setup.py requirements with requirements.txt.in|2018-05-15 16:57:02|
-|[Link to commit](https://github.com/mozilla-releng/addonscript/commit/24408061c1ff8cd2799a1865c56ce8659101bb3f)|Update scriptworker from 11.0.0 to 11.1.0|2018-05-17 09:57:29|
-|[Link to commit](https://github.com/mozilla-releng/addonscript/commit/34f18115164aec34814b23cf17dddbe99bd2efa1)|Update scriptworker from 11.0.0 to 11.1.0|2018-05-17 09:57:28|
-|[Link to commit](https://github.com/mozilla-releng/addonscript/commit/b73b44300f0558a663ed37e0a9eac9ff0347b5b7)|Update virtualenv from 15.2.0 to 16.0.0|2018-05-17 00:27:29|
+|[Link to commit](https://github.com/mozilla-releng/mozapkpublisher/commit/ac653d9dccec8624f8ff25f31b994757cca5fd79)|0.9.2|2018-11-08 09:57:02|
+|[Link to commit](https://github.com/mozilla-releng/mozapkpublisher/commit/faf0e1d2f62664cf325375ae90e546a665d00544)|Add requirements.txt.in in package so setup.py can use it|2018-11-08 09:56:04|
+|[Link to commit](https://github.com/mozilla-releng/mozapkpublisher/commit/5e6e12b4f158efcfdc2b2e38f111087caf2c79d4)|0.9.1|2018-11-07 19:08:58|
 
-|	signingscript	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/signingscript.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/signingscript.json)	| 
+|	OpenCloudConfig	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/OpenCloudConfig.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/OpenCloudConfig.json)	| 
 |:----------------:|:-------------------------------------:|:---------------------------------:| 
  
 |      Repository      |                   Last commit               |    Deploy time       | 
 |:--------------------:|:-------------------------------------------:|:--------------------:| 
-|[Link to commit](https://github.com/mozilla-releng/signingscript/commit/c15e3121714bef54103d4d7b126b470054b79d39)|9.5.1|2018-11-23 12:48:01|
-|[Link to commit](https://github.com/mozilla-releng/signingscript/commit/57943a9e24a28ecdfc74062a9adc523288d557e0)|Fix SHA1 detection for APKs|2018-11-23 12:46:38|
-|[Link to commit](https://github.com/mozilla-releng/signingscript/commit/02621783091e6139d313b7ef27a33314f9e1b596)|9.5.0|2018-11-22 15:12:48|
-|[Link to commit](https://github.com/mozilla-releng/signingscript/commit/75e15a0b743977c70e1b2ad1651d267706063f02)|Generalize APK format to  Keep autograph_focus for migration purpose|2018-11-22 14:49:05|
+|[Link to commit](https://github.com/mozilla-releng/OpenCloudConfig/commit/4053e2c3c0db9b63ff74ca32c9bb6c14ccc4f08a)|Bug 1485628 - disable service pack updates & reboots  deploy: gecko-t-win10-64 gecko-t-win10-64-gpu|2018-11-28 17:27:08|
+|[Link to commit](https://github.com/mozilla-releng/OpenCloudConfig/commit/bbdfd298d8fed84fab86e30d4322b365fb01a604)|Bug 1485628 - disable service pack updates & reboots  deploy: gecko-t-win10-64 gecko-t-win10-64-gpu|2018-11-28 17:18:59|
+|[Link to commit](https://github.com/mozilla-releng/OpenCloudConfig/commit/bcb4c6ddd1c4efdc7fc07eb079b934e7a76ca12d)|Bug 1485628 - disable service pack updates & reboots  deploy: gecko-t-win10-64 gecko-t-win10-64-gpu|2018-11-28 17:10:22|
+|[Link to commit](https://github.com/mozilla-releng/OpenCloudConfig/commit/3c874a7b7ab236ec1939728b43451e44eb50ff6f)|Bug 1485628 - disable service pack updates & reboots (#216)  deploy: gecko-t-win10-64 gecko-t-win10-64-gpu|2018-11-28 17:08:20|
 
 |	pushapkscript	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/pushapkscript.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/pushapkscript.json)	| 
 |:----------------:|:-------------------------------------:|:---------------------------------:| 
@@ -238,15 +226,67 @@
 |[Link to commit](https://github.com/mozilla-releng/pushapkscript/commit/0fa1fec2424cba14dfa2c22ab42e44e937ffedc4)|Merge pull request #50 from mitchhentges/fix-travis-jdk-switcher  Resolves Travis Xenial image using Java11 instead of Java8|2018-11-09 22:28:06|
 |[Link to commit](https://github.com/mozilla-releng/pushapkscript/commit/2e8cc150527906f7d9bd23658c96f5d4221fdcf9)|Manually adds java 8 to front of $PATH for xenial Travis builds|2018-11-09 21:41:37|
 
-|	taskcluster-queue	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/taskcluster-queue.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/taskcluster-queue.json)	| 
+|	pushsnapscript	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/pushsnapscript.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/pushsnapscript.json)	| 
 |:----------------:|:-------------------------------------:|:---------------------------------:| 
  
 |      Repository      |                   Last commit               |    Deploy time       | 
 |:--------------------:|:-------------------------------------------:|:--------------------:| 
-|[Link to commit](https://github.com/taskcluster/taskcluster-queue/commit/c3a424aa0811c0b8bef42219a485d5a179a14ba2)|Merge pull request #304 from djmitche/bug1509189  Bug 1509189 - use unique table names to avoid conflicts|2018-11-30 02:12:03|
-|[Link to commit](https://github.com/taskcluster/taskcluster-queue/commit/cb8f3946830b982b58d2f93b99202cab15f40719)|Bug 1509189 - use unique table names to avoid conflicts  Taskcluster-Github already does something like this.  The tables get cleaned out and should have no rows at test completion, so this doesn't use a lot of space.  There's no limit (aside from space) on the number of tables in an account.|2018-11-29 01:12:10|
-|[Link to commit](https://github.com/taskcluster/taskcluster-queue/commit/eae5a8ff58e6edaac15fd95d273509c8045da3f6)|Bug 1509186 - remove references to taskcluster.net from the API description|2018-11-26 18:08:58|
-|[Link to commit](https://github.com/taskcluster/taskcluster-queue/commit/9595f61cd17ad72c315e52d7d950026527ded5c6)|Merge pull request #303 from djmitche/bug1456909  Bug 1456909 - use monitor.oneShot()|2018-11-26 22:05:11|
+|[Link to commit](https://github.com/mozilla-releng/pushsnapscript/commit/1de161f0b36d3840806fecf41c5b84f30e1ac8df)|0.2.4|2018-10-05 13:09:12|
+|[Link to commit](https://github.com/mozilla-releng/pushsnapscript/commit/45c2f94c2cfc0852f996c68a94549298ba9eb4a6)|Bug 1491262 - part 2: Fix esr lookup|2018-10-05 13:05:20|
+|[Link to commit](https://github.com/mozilla-releng/pushsnapscript/commit/46ce3fda359015916a55fb6c6e3eca19816597a2)|0.2.3|2018-09-25 08:43:04|
+|[Link to commit](https://github.com/mozilla-releng/pushsnapscript/commit/ed0c6c0e2d432ffe6f9fdcacc9b02832ee61af08)|Fix deprecation warning|2018-09-25 08:35:36|
+|[Link to commit](https://github.com/mozilla-releng/pushsnapscript/commit/09b8fccbeddb9c727d5b8df8fd95c00c86471c5f)|Bug 1491262 - Make snap store push idempotent|2018-09-21 14:35:37|
+
+|	scriptworker	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/scriptworker.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/scriptworker.json)	| 
+|:----------------:|:-------------------------------------:|:---------------------------------:| 
+ 
+|      Repository      |                   Last commit               |    Deploy time       | 
+|:--------------------:|:-------------------------------------------:|:--------------------:| 
+|[Link to commit](https://github.com/mozilla-releng/scriptworker/commit/0b1e25dfc8c1a6d2b4de965fb1d1f3a6955e9a9f)|17.0.0|2018-11-27 17:46:52|
+|[Link to commit](https://github.com/mozilla-releng/scriptworker/commit/ae4cc4de36bd59a235c7a48e17d15c827caa3024)|Merge pull request #269 from escapewindow/pip-compile-multi  Pip compile multi|2018-11-13 21:32:49|
+|[Link to commit](https://github.com/mozilla-releng/scriptworker/commit/48f9c9ca3c0d1eaae3c41d76f9166224a6eee45f)|update pinned requirements|2018-11-13 21:10:04|
+|[Link to commit](https://github.com/mozilla-releng/scriptworker/commit/f760315f4f9f06e9492f4c87d8b79cfa0bde61c6)|address review comments|2018-11-13 21:09:55|
+|[Link to commit](https://github.com/mozilla-releng/scriptworker/commit/648de55b994a2fb9f57bd6991e7a8a54ef3a4790)|pin hashes via pip-compile-multi in docker  I've been pinning mac-specific wheel hashes in dephash, which is wrong.|2018-10-30 23:37:30|
+
+|	services	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/services.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/services.json)	| 
+|:----------------:|:-------------------------------------:|:---------------------------------:| 
+ 
+|      Repository      |                   Last commit               |    Deploy time       | 
+|:--------------------:|:-------------------------------------------:|:--------------------:| 
+|[Link to commit](https://github.com/mozilla/release-services/commit/ae0004b50d4d2252d5b8ed3d3d3aa232a1412d14)|staticanalysis/bot: Filter clang-format publishable issues by their path. (#1689)|2018-11-20 15:36:16|
+|[Link to commit](https://github.com/mozilla/release-services/commit/f5434b1aff3d78db8bfceae7cfa872382c4b1d9f)|codecoverage/backend: Add test for codecoverage backend with mocked rq and Redis (#1673)|2018-11-20 11:57:13|
+|[Link to commit](https://github.com/mozilla/release-services/commit/88b939c265b26fe9e960d7a3361648d9ea522af6)|uplift/bot: Add a BUGZILLA_COMMENT_ONLY setting in order to report failed uplifts without cancelling requests. (#1680)|2018-11-20 09:34:34|
+|[Link to commit](https://github.com/mozilla/release-services/commit/3399eed333cb502e46c5a7b83f3673d0fb4faafb)|shipit/frontent: add testing config (#1687)  At this point it is the same as staging.js|2018-11-20 01:39:45|
+|[Link to commit](https://github.com/mozilla/release-services/commit/37bc7cafe221c5cea7d33041125d95312fe7757f)|shipit/api: update release status (#1688)  In the future we will need to update the release status explicitly from  a in-tree scheduled task, so we mark a release as completed only after  all required tasks are done (bouncer, tests, etc).|2018-11-19 20:45:16|
+
+|	ship-it	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/ship-it.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/ship-it.json)	| 
+|:----------------:|:-------------------------------------:|:---------------------------------:| 
+ 
+|      Repository      |                   Last commit               |    Deploy time       | 
+|:--------------------:|:-------------------------------------------:|:--------------------:| 
+|[Link to commit](https://github.com/mozilla-releng/ship-it/commit/f8d9c823a7fc598ba5e6623dd1f4e65c1de38393)|Add comment about syncing v1 and v2 configs (#246)|2018-11-30 19:20:47|
+|[Link to commit](https://github.com/mozilla-releng/ship-it/commit/f1a6646f20ef404c2667d3b714c3ef90b6719546)|Bug 1511159 - Disable firefox releases (#245)|2018-11-30 17:07:43|
+
+|	shipitscript	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/shipitscript.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/shipitscript.json)	| 
+|:----------------:|:-------------------------------------:|:---------------------------------:| 
+ 
+|      Repository      |                   Last commit               |    Deploy time       | 
+|:--------------------:|:-------------------------------------------:|:--------------------:| 
+|[Link to commit](https://github.com/mozilla-releng/shipitscript/commit/4c89c1b239fd8415e1225ba738ba820342bd8081)|Add support for Ship-it v2 (#14)|2018-11-21 16:33:53|
+|[Link to commit](https://github.com/mozilla-releng/shipitscript/commit/0c892801fc9ad80e3a12b80ab69a7e3527ec0eea)|Address comments|2018-11-21 15:44:59|
+|[Link to commit](https://github.com/mozilla-releng/shipitscript/commit/3033ccfe619289bfd022df1250a924f995ac33b8)|Revert local temp canges|2018-11-20 04:44:21|
+|[Link to commit](https://github.com/mozilla-releng/shipitscript/commit/fb22074bb0e5bc26373cf5c2305e89f2a45eae25)|Bump version to 3.0.0|2018-11-20 04:24:43|
+|[Link to commit](https://github.com/mozilla-releng/shipitscript/commit/2032f7bfc6c1629fa783a1af52f42ac51668d7f2)|Add support for masrk as shipped v2|2018-11-20 04:20:35|
+
+|	signingscript	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/signingscript.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/signingscript.json)	| 
+|:----------------:|:-------------------------------------:|:---------------------------------:| 
+ 
+|      Repository      |                   Last commit               |    Deploy time       | 
+|:--------------------:|:-------------------------------------------:|:--------------------:| 
+|[Link to commit](https://github.com/mozilla-releng/signingscript/commit/c15e3121714bef54103d4d7b126b470054b79d39)|9.5.1|2018-11-23 12:48:01|
+|[Link to commit](https://github.com/mozilla-releng/signingscript/commit/57943a9e24a28ecdfc74062a9adc523288d557e0)|Fix SHA1 detection for APKs|2018-11-23 12:46:38|
+|[Link to commit](https://github.com/mozilla-releng/signingscript/commit/02621783091e6139d313b7ef27a33314f9e1b596)|9.5.0|2018-11-22 15:12:48|
+|[Link to commit](https://github.com/mozilla-releng/signingscript/commit/75e15a0b743977c70e1b2ad1651d267706063f02)|Generalize APK format to  Keep autograph_focus for migration purpose|2018-11-22 14:49:05|
 
 |	signtool	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/signtool.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/signtool.json)	| 
 |:----------------:|:-------------------------------------:|:---------------------------------:| 
@@ -268,65 +308,22 @@
 |[Link to commit](https://github.com/taskcluster/taskcluster-auth/commit/9babc5e6d48fc27013e58e8e67eb085bfaa6561e)|Merge pull request #186 from djmitche/bug1509154  Bug 1509154 - await row removals|2018-11-30 02:24:34|
 |[Link to commit](https://github.com/taskcluster/taskcluster-auth/commit/6375db436a015e587979ded3e94fe36cd90ec7c6)|Bug 1509154 - await row removals|2018-11-29 01:23:01|
 |[Link to commit](https://github.com/taskcluster/taskcluster-auth/commit/b8c3dfe5dc51e448e3c4773b7bd386e8db37ffe9)|Bug 1509089 - remove LOCK_ROLES support  This was a big old hack meant to block changes to roles during the transition to storing roles in a blob.  It's not needed anymore.|2018-11-28 22:01:44|
-|[Link to commit](https://github.com/taskcluster/taskcluster-auth/commit/68bd2858a24e54fb079e76b8997b1ef19bfb5f88)|Merge pull request #184 from djmitche/bug1456909  Bug 1456909 - use monitor.oneShot|2018-11-26 22:08:53|
 
-|	pushsnapscript	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/pushsnapscript.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/pushsnapscript.json)	| 
+|	taskcluster-queue	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/taskcluster-queue.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/taskcluster-queue.json)	| 
 |:----------------:|:-------------------------------------:|:---------------------------------:| 
  
 |      Repository      |                   Last commit               |    Deploy time       | 
 |:--------------------:|:-------------------------------------------:|:--------------------:| 
-|[Link to commit](https://github.com/mozilla-releng/pushsnapscript/commit/1de161f0b36d3840806fecf41c5b84f30e1ac8df)|0.2.4|2018-10-05 13:09:12|
-|[Link to commit](https://github.com/mozilla-releng/pushsnapscript/commit/45c2f94c2cfc0852f996c68a94549298ba9eb4a6)|Bug 1491262 - part 2: Fix esr lookup|2018-10-05 13:05:20|
-|[Link to commit](https://github.com/mozilla-releng/pushsnapscript/commit/46ce3fda359015916a55fb6c6e3eca19816597a2)|0.2.3|2018-09-25 08:43:04|
-|[Link to commit](https://github.com/mozilla-releng/pushsnapscript/commit/ed0c6c0e2d432ffe6f9fdcacc9b02832ee61af08)|Fix deprecation warning|2018-09-25 08:35:36|
-|[Link to commit](https://github.com/mozilla-releng/pushsnapscript/commit/09b8fccbeddb9c727d5b8df8fd95c00c86471c5f)|Bug 1491262 - Make snap store push idempotent|2018-09-21 14:35:37|
+|[Link to commit](https://github.com/taskcluster/taskcluster-queue/commit/c3a424aa0811c0b8bef42219a485d5a179a14ba2)|Merge pull request #304 from djmitche/bug1509189  Bug 1509189 - use unique table names to avoid conflicts|2018-11-30 02:12:03|
+|[Link to commit](https://github.com/taskcluster/taskcluster-queue/commit/cb8f3946830b982b58d2f93b99202cab15f40719)|Bug 1509189 - use unique table names to avoid conflicts  Taskcluster-Github already does something like this.  The tables get cleaned out and should have no rows at test completion, so this doesn't use a lot of space.  There's no limit (aside from space) on the number of tables in an account.|2018-11-29 01:12:10|
 
-|	build-puppet	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/build-puppet.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/build-puppet.json)	| 
+|	treescript	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/treescript.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/treescript.json)	| 
 |:----------------:|:-------------------------------------:|:---------------------------------:| 
  
 |      Repository      |                   Last commit               |    Deploy time       | 
 |:--------------------:|:-------------------------------------------:|:--------------------:| 
-|[Link to commit](https://github.com/mozilla-releng/build-puppet/commit/9f3cf327c3a20d1954ee2627a15b2e8dfa86ea8d)|Force reboot linux workers (#305)    Force reboot linux workers      Force reboot linux workers      Force reboot linux workers      Force reboot linux workers      Create a separate reboot command for OSX and Linux workers      Create a separate reboot command for OSX and Linux workers      Create a separate reboot command for OSX and Linux workers|2018-12-03 08:28:30|
-|[Link to commit](https://github.com/mozilla-releng/build-puppet/commit/6d735b7ae012510bd96641ae01587eefa19fa744)|Bug 1511145: don't handle Firefox in releaserunner3 (#316)  Using fake values in case we don't hablde empty arrays properly|2018-11-30 17:10:54|
-|[Link to commit](https://github.com/mozilla-releng/build-puppet/commit/0b8d96d712cfc710e2ca3d08ecaa5682369be068)|Bump scriptworker to 17.0.1 (#315)|2018-11-29 17:12:10|
-|[Link to commit](https://github.com/mozilla-releng/build-puppet/commit/de413d0e22b0f5d478efc9dc1ef5dc3233f1eec3)|Merge pull request #312 from mitchhentges/pushapk-mobile-dep-settings  Adds mobile-dep pushapk env config|2018-11-28 23:14:51|
-|[Link to commit](https://github.com/mozilla-releng/build-puppet/commit/3f41e7d42861eab53e8533a9ade6cfce509e12d8)|Adds note that taskcluster_client_id should be simplified|2018-11-28 21:17:31|
-
-|	scriptworker	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/scriptworker.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/scriptworker.json)	| 
-|:----------------:|:-------------------------------------:|:---------------------------------:| 
- 
-|      Repository      |                   Last commit               |    Deploy time       | 
-|:--------------------:|:-------------------------------------------:|:--------------------:| 
-|[Link to commit](https://github.com/mozilla-releng/scriptworker/commit/0b1e25dfc8c1a6d2b4de965fb1d1f3a6955e9a9f)|17.0.0|2018-11-27 17:46:52|
-|[Link to commit](https://github.com/mozilla-releng/scriptworker/commit/ae4cc4de36bd59a235c7a48e17d15c827caa3024)|Merge pull request #269 from escapewindow/pip-compile-multi  Pip compile multi|2018-11-13 21:32:49|
-|[Link to commit](https://github.com/mozilla-releng/scriptworker/commit/48f9c9ca3c0d1eaae3c41d76f9166224a6eee45f)|update pinned requirements|2018-11-13 21:10:04|
-|[Link to commit](https://github.com/mozilla-releng/scriptworker/commit/f760315f4f9f06e9492f4c87d8b79cfa0bde61c6)|address review comments|2018-11-13 21:09:55|
-|[Link to commit](https://github.com/mozilla-releng/scriptworker/commit/648de55b994a2fb9f57bd6991e7a8a54ef3a4790)|pin hashes via pip-compile-multi in docker  I've been pinning mac-specific wheel hashes in dephash, which is wrong.|2018-10-30 23:37:30|
-
-|	build-cloud-tools	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/build-cloud-tools.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/build-cloud-tools.json)	| 
-|:----------------:|:-------------------------------------:|:---------------------------------:| 
- 
-|      Repository      |                   Last commit               |    Deploy time       | 
-|:--------------------:|:-------------------------------------------:|:--------------------:| 
-|[Link to commit](https://github.com/mozilla-releng/build-cloud-tools/commit/cb2ede208a3dda6df742eb0f251827762931f1d1)|Merge branch 'La0-buildhub'|2018-11-29 02:03:48|
-|[Link to commit](https://github.com/mozilla-releng/build-cloud-tools/commit/62d5a4b0cf4c9d52836bc196680cca8ca08a4d53)|Add CNAME for buildhub.moz.tools|2018-11-27 09:13:51|
-
-|	mozapkpublisher	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/mozapkpublisher.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/mozapkpublisher.json)	| 
-|:----------------:|:-------------------------------------:|:---------------------------------:| 
- 
-|      Repository      |                   Last commit               |    Deploy time       | 
-|:--------------------:|:-------------------------------------------:|:--------------------:| 
-|[Link to commit](https://github.com/mozilla-releng/mozapkpublisher/commit/ac653d9dccec8624f8ff25f31b994757cca5fd79)|0.9.2|2018-11-08 09:57:02|
-|[Link to commit](https://github.com/mozilla-releng/mozapkpublisher/commit/faf0e1d2f62664cf325375ae90e546a665d00544)|Add requirements.txt.in in package so setup.py can use it|2018-11-08 09:56:04|
-|[Link to commit](https://github.com/mozilla-releng/mozapkpublisher/commit/5e6e12b4f158efcfdc2b2e38f111087caf2c79d4)|0.9.1|2018-11-07 19:08:58|
-
-|	OpenCloudConfig	|	[MarkDown](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/OpenCloudConfig.md)	|	[Json](https://github.com/Akhliskun/firefox-infra-changelog/blob/master/git_files/OpenCloudConfig.json)	| 
-|:----------------:|:-------------------------------------:|:---------------------------------:| 
- 
-|      Repository      |                   Last commit               |    Deploy time       | 
-|:--------------------:|:-------------------------------------------:|:--------------------:| 
-|[Link to commit](https://github.com/mozilla-releng/OpenCloudConfig/commit/4053e2c3c0db9b63ff74ca32c9bb6c14ccc4f08a)|Bug 1485628 - disable service pack updates & reboots  deploy: gecko-t-win10-64 gecko-t-win10-64-gpu|2018-11-28 17:27:08|
-|[Link to commit](https://github.com/mozilla-releng/OpenCloudConfig/commit/bbdfd298d8fed84fab86e30d4322b365fb01a604)|Bug 1485628 - disable service pack updates & reboots  deploy: gecko-t-win10-64 gecko-t-win10-64-gpu|2018-11-28 17:18:59|
-|[Link to commit](https://github.com/mozilla-releng/OpenCloudConfig/commit/bcb4c6ddd1c4efdc7fc07eb079b934e7a76ca12d)|Bug 1485628 - disable service pack updates & reboots  deploy: gecko-t-win10-64 gecko-t-win10-64-gpu|2018-11-28 17:10:22|
-|[Link to commit](https://github.com/mozilla-releng/OpenCloudConfig/commit/3c874a7b7ab236ec1939728b43451e44eb50ff6f)|Bug 1485628 - disable service pack updates & reboots (#216)  deploy: gecko-t-win10-64 gecko-t-win10-64-gpu|2018-11-28 17:08:20|
-|[Link to commit](https://github.com/mozilla-releng/OpenCloudConfig/commit/c421eb84b254a74a84916ad5bd1d957bea060f33)|Bug 1510220 - defer upgrades in registry  deploy: gecko-t-win10-64 gecko-t-win10-64-gpu|2018-11-27 13:39:44|
+|[Link to commit](https://github.com/mozilla-releng/treescript/commit/5513bb6bfd14c076aadbf275c2a9f3cffb3fb30a)|Bump version.|2018-10-31 21:21:07|
+|[Link to commit](https://github.com/mozilla-releng/treescript/commit/b34cbe8f210f55b9e29eb438f1cd34b6390250a7)|Bug 1495464: Update hg.mozilla.org fingerprint.|2018-10-31 21:18:25|
+|[Link to commit](https://github.com/mozilla-releng/treescript/commit/4f9700637f3c90610207fea918f15e10b6dfa44b)|Update virtualenv from 16.0.0 to 16.1.0|2018-10-31 16:31:24|
+|[Link to commit](https://github.com/mozilla-releng/treescript/commit/26f431b8a1c975156ca16e7ba4416203e912c89c)|Update virtualenv from 16.0.0 to 16.1.0|2018-10-31 16:31:22|
+|[Link to commit](https://github.com/mozilla-releng/treescript/commit/340147bcf13fd0407c26491501ea6c8fe162598d)|Update pyparsing from 2.2.0 to 2.3.0|2018-10-31 08:27:23|


### PR DESCRIPTION
This PR will:
-change the markdown header by adding the version and release date for the repositories with tags
-remove the unused variable 'last_checked' in 'create_md_table' function
-update .json and .md files for git repositories:
e.g 
## REPOSITORY NAME: BEETMOVERSCRIPT
 CURRENT VERSION: 8.0.0 RELEASED ON WED, 28 NOV 2018 01:08:55 GMT
